### PR TITLE
move chatapp build from local docker to codebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,14 @@ The built-in admin dashboard (`/admin`) provides comprehensive usage analytics:
 |------|----------------|---------|
 | **Node.js** | 18.x+ | CDK runtime |
 | **AWS CDK CLI** | 2.x | Infrastructure deployment |
-| **Docker** | 20.x | Container builds |
 | **AWS CLI** | 2.x | AWS resource management |
 
 Install CDK CLI globally:
 ```bash
 npm install -g aws-cdk
 ```
+
+Note: Docker is not required locally - all container builds are handled by AWS CodeBuild.
 
 ### AWS Requirements
 
@@ -201,7 +202,6 @@ The deployment creates:
 Options:
   --region <region>    AWS region (default: us-east-1)
   --profile <profile>  AWS CLI profile to use
-  --skip-build         Skip Docker image builds
   --dry-run            Show what would be deployed without deploying
 ```
 

--- a/cdk/destroy-all.sh
+++ b/cdk/destroy-all.sh
@@ -167,25 +167,7 @@ echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━�
 echo -e "${BLUE}Step 2: Clean up remaining resources${NC}"
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 
-# Clean up ECR repository (created by deploy-all.sh, not CDK)
-echo -e "${YELLOW}Cleaning up ECR repository...${NC}"
-if [ "$DRY_RUN" = true ]; then
-    echo -e "${CYAN}[DRY RUN] Would delete ECR repository: $APP_NAME${NC}"
-else
-    # Delete all images first, then delete the repository
-    if aws ecr describe-repositories --repository-names "$APP_NAME" --region "$AWS_REGION" > /dev/null 2>&1; then
-        # Delete all images in the repository
-        IMAGES=$(aws ecr list-images --repository-name "$APP_NAME" --region "$AWS_REGION" --query 'imageIds[*]' --output json 2>/dev/null)
-        if [ "$IMAGES" != "[]" ] && [ -n "$IMAGES" ]; then
-            aws ecr batch-delete-image --repository-name "$APP_NAME" --region "$AWS_REGION" --image-ids "$IMAGES" > /dev/null 2>&1 || true
-        fi
-        # Delete the repository
-        aws ecr delete-repository --repository-name "$APP_NAME" --region "$AWS_REGION" --force > /dev/null 2>&1 || true
-        echo -e "${GREEN}Deleted ECR repository: $APP_NAME${NC}"
-    else
-        echo -e "${YELLOW}ECR repository $APP_NAME not found (may already be deleted)${NC}"
-    fi
-fi
+# Note: ECR repositories are now managed by CDK and deleted automatically
 
 # Clean up CloudWatch log groups that may have been created outside CDK
 echo -e "${YELLOW}Cleaning up CloudWatch log groups...${NC}"
@@ -231,10 +213,10 @@ if [ "$DRY_RUN" = true ]; then
     echo -e "${CYAN}Run without --dry-run to perform actual cleanup.${NC}"
 else
     echo -e "${CYAN}Summary of destroyed resources:${NC}"
-    echo "  - ChatApp ECS Express Mode service and ECR repository"
-    echo "  - Agent infrastructure (ECR, CodeBuild, CfnRuntime, Observability)"
-    echo "  - Bedrock resources (Guardrail, Knowledge Base, Memory)"
-    echo "  - Foundation resources (Cognito, DynamoDB, IAM roles, Secrets)"
+    echo "  - ChatApp (ECS Express Mode, ECR, CodeBuild, S3 source bucket)"
+    echo "  - Agent (ECR, CodeBuild, CfnRuntime, Observability)"
+    echo "  - Bedrock (Guardrail, Knowledge Base, Memory)"
+    echo "  - Foundation (Cognito, DynamoDB, IAM roles, Secrets)"
     echo "  - CloudWatch log groups"
     echo ""
     echo -e "${YELLOW}Note: Some resources may take a few minutes to fully delete.${NC}"


### PR DESCRIPTION
changed:

**chatapp-stack.ts:**

- Added ECR repository creation (instead of importing)
- Added S3 source bucket for CodeBuild
- Added CodeBuild project for AMD64 Docker builds
- Added source deployment from chatapp/ directory
- Added build trigger and waiter (same pattern as agent-stack)
- ECS service now depends on build completion

**deploy-all.sh:**

- Removed --skip-build option
- Removed Docker build step (~40 lines)
- Removed CHATAPP_DIR variable
- Removed Step 8 (ECS deployment config - now in CDK)
- Updated comments to reflect CodeBuild handles all builds

**README.md:**

- Removed Docker from prerequisites
- Added note that CodeBuild handles all container builds
- Removed --skip-build from deployment options

Now the deployment is fully CDK-native with no local Docker dependency. 

All builds happen on AWS CodeBuild.