### PR TITLE
fix(chatapp): streaming keepalive, memory rendering, and cache-clear fixes

### DIFF
--- a/chatapp/app/agentcore/memory.py
+++ b/chatapp/app/agentcore/memory.py
@@ -4,6 +4,7 @@ This module provides the MemoryClient class for fetching event and semantic
 memory from AgentCore Memory service.
 """
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import List, Optional
@@ -14,6 +15,41 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from app.config import get_config
+
+
+def _format_event_content(raw_text, default_role):
+    """Unwrap a stored Strands message envelope into (role, display_text).
+
+    Some agents persist the full message object as the event text, e.g.:
+        {"message": {"role": "assistant", "content": [{"text": "..."},
+                                                       {"toolUse": {...}}]}, ...}
+    Returns the message's real role plus the concatenated human-readable text
+    blocks (tool-use / tool-result blocks are dropped). Plain-text events are
+    returned unchanged.
+    """
+    if not raw_text or not isinstance(raw_text, str):
+        return default_role, raw_text or ""
+    if not raw_text.lstrip().startswith("{"):
+        return default_role, raw_text
+    try:
+        obj = json.loads(raw_text)
+    except (ValueError, TypeError):
+        return default_role, raw_text
+    if not isinstance(obj, dict) or not isinstance(obj.get("message"), dict):
+        return default_role, raw_text
+    msg = obj["message"]
+    role = msg.get("role", default_role)
+    role = role.lower() if isinstance(role, str) else default_role
+    content = msg.get("content")
+    if isinstance(content, str):
+        return role, content
+    if not isinstance(content, list):
+        return role, raw_text
+    texts = [
+        b["text"] for b in content
+        if isinstance(b, dict) and isinstance(b.get("text"), str)
+    ]
+    return role, "\n\n".join(texts).strip()
 
 
 logger = logging.getLogger(__name__)
@@ -147,7 +183,11 @@ class MemoryClient:
                             role = role.lower()
                         content_obj = conv.get('content', {})
                         text = content_obj.get('text', '')
-                        
+
+                        # Unwrap Strands message envelopes so the
+                        # Events panel shows clean text, not raw JSON.
+                        role, text = _format_event_content(text, role)
+
                         if text:
                             # Handle timestamp
                             timestamp = evt.get('eventTimestamp')

--- a/chatapp/app/routes/chat.py
+++ b/chatapp/app/routes/chat.py
@@ -154,13 +154,47 @@ async def _stream_chat_response(
     accumulated_output: list[str] = []
     # Accumulate tool/KB result content to ground the faithfulness evaluator
     accumulated_context: list[str] = []
-    
-    async for event in client.invoke_stream(
-        prompt=prompt,
-        session_id=session_id,
-        user_id=user_id,
-        model_id=model_id,
-    ):
+
+    # Keepalive via asyncio.Queue + producer task.
+    #
+    # asyncio.wait_for() on an async generator's __anext__() is unsafe: when
+    # the timeout fires it cancels the coroutine and leaves the generator in a
+    # broken state. The safe pattern: run the generator in a separate task that
+    # pushes events onto a Queue. The consumer waits on the queue with a
+    # timeout; on timeout it yields an SSE comment (invisible to the browser,
+    # resets the ALB/proxy idle timer) and loops.
+    KEEPALIVE_INTERVAL = 15  # seconds — well under typical 60s LB idle timeouts
+    _SENTINEL = object()
+    queue: asyncio.Queue = asyncio.Queue(maxsize=64)
+
+    async def _producer():
+        try:
+            async for ev in client.invoke_stream(
+                prompt=prompt,
+                session_id=session_id,
+                user_id=user_id,
+                model_id=model_id,
+            ):
+                await queue.put(ev)
+        except Exception as exc:
+            logger.error("AgentCore stream error in producer: %s", exc)
+        finally:
+            await queue.put(_SENTINEL)
+
+    producer_task = asyncio.create_task(_producer())
+
+    try:
+      while True:
+        try:
+            item = await asyncio.wait_for(queue.get(), timeout=KEEPALIVE_INTERVAL)
+        except asyncio.TimeoutError:
+            yield ": keepalive\n\n"
+            continue
+
+        if item is _SENTINEL:
+            break
+
+        event = item
         # Inject paragraph break when message text follows a tool result
         # Only if previous text ended a sentence (avoid splitting "Here" / "'s a full overview")
         if isinstance(event, MessageEvent) and after_tool and event.content.strip():
@@ -238,9 +272,15 @@ async def _stream_chat_response(
             )
         
         yield event.to_sse_format()
-    
+
+    finally:
+        producer_task.cancel()
+        try:
+            await producer_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
     # Handle any remaining pending tool uses (tools that started but never completed)
-    # Mark them as errors since they didn't produce a result
     for tool_use_id, tool_info in pending_tool_uses.items():
         tool_name = tool_info["tool_name"]
         tool_usage_counts[tool_name]["error_count"] += 1

--- a/chatapp/app/static/js/chat.js
+++ b/chatapp/app/static/js/chat.js
@@ -534,13 +534,7 @@ function selectTemplate(promptDetail) {
     }
 }
 
-/**
- * Clear the cached templates.
- * Call this when templates are updated via admin.
- */
-function clearTemplatesCache() {
-    cachedTemplates = null;
-}
+// clearTemplatesCache() is defined above (clears both in-memory and localStorage)
 
 /**
  * Prefetch templates in the background on page load.

--- a/chatapp/app/templates/chat.html
+++ b/chatapp/app/templates/chat.html
@@ -211,5 +211,5 @@
     window.chatLogoUrl = {{ (chat_logo_url if chat_logo_url is defined else '/static/chat-placeholder.svg')|tojson }};
 </script>
 <!-- Chat application JavaScript -->
-<script src="/static/js/chat.js"></script>
+<script src="/static/js/chat.js?v=20260614"></script>
 {% endblock %}

--- a/chatapp/app/templates/components/sidebar.html
+++ b/chatapp/app/templates/components/sidebar.html
@@ -264,7 +264,30 @@ async function loadEventMemory(forceRefresh) {
     }
 }
 
+function unwrapEventEnvelope(raw) {
+    if (typeof raw !== 'string') return { role: null, text: raw || '' };
+    if (raw.trim().charAt(0) !== '{') return { role: null, text: raw };
+    var obj;
+    try { obj = JSON.parse(raw); } catch (e) { return { role: null, text: raw }; }
+    if (!obj || typeof obj.message !== 'object' || obj.message === null) return { role: null, text: raw };
+    var msg = obj.message;
+    var role = (typeof msg.role === 'string') ? msg.role.toLowerCase() : null;
+    var content = msg.content;
+    if (typeof content === 'string') return { role: role, text: content };
+    if (!Array.isArray(content)) return { role: role, text: raw };
+    var texts = [];
+    for (var i = 0; i < content.length; i++) {
+        var b = content[i];
+        if (b && typeof b === 'object' && typeof b.text === 'string') texts.push(b.text);
+    }
+    return { role: role, text: texts.join('\n\n').trim() };
+}
+
 function renderEventMemoryItems(messages, container) {
+    messages = (messages || []).map(function(ev) {
+        var un = unwrapEventEnvelope(ev.content);
+        return { role: un.role || ev.role, content: un.text, timestamp: ev.timestamp };
+    }).filter(function(ev) { return ev.content && String(ev.content).trim(); });
     if (!messages || messages.length === 0) {
         container.innerHTML = '<div class="text-center py-8"><svg class="w-12 h-12 mx-auto mb-3" style="color: var(--sidebar-empty-icon);" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg><p class="text-sm" style="color: var(--sidebar-text-muted);">No conversation history yet</p><p class="text-xs mt-1" style="color: var(--sidebar-text-muted); opacity: 0.7;">Start chatting to see events here</p></div>';
         return;

--- a/chatapp/app/templates/login.html
+++ b/chatapp/app/templates/login.html
@@ -102,6 +102,12 @@
 
 {% block scripts %}
 <script>
+try {
+    localStorage.removeItem('agentcore-templates-cache');
+    localStorage.removeItem('agentcore-memory-cache');
+} catch (e) { /* localStorage unavailable — ignore */ }
+</script>
+<script>
 function togglePassword() {
     const passwordInput = document.getElementById('password');
     const eyeIcon = document.getElementById('eye-icon');


### PR DESCRIPTION
## Summary
A set of frontend and streaming reliability fixes for the chat app. No infra
or agent-backend changes. 5 commits, 6 files (+121 / −18).

## Changes

### Streaming reliability
- **SSE keepalive (`routes/chat.py`)** — Adds a 15s heartbeat to the chat
  stream to prevent ALB/HTTP2 from resetting idle connections during long
  agent turns. Reworks the stream loop to run the AgentCore generator in a
  producer task feeding an `asyncio.Queue`, with the consumer emitting an SSE
  comment on timeout. This avoids the unsafe `wait_for()`-on-`__anext__()`
  pattern that can leave the generator in a broken state.

### Memory viewer
- **Unwrap Strands message envelopes (`agentcore/memory.py`, `sidebar.html`)** —
  The Events panel was rendering raw JSON for events stored as full Strands
  message objects. Adds `_format_event_content` to extract the real role and
  concatenate human-readable text blocks (dropping tool-use/tool-result
  blocks); plain-text events are passed through unchanged.

### Cache correctness
- **Cache-busting for chat.js (`chat.html`)** — Adds a version query param to
  the script tag so browsers don't serve a stale bundle after deploys.
- **Clear template/memory cache on login (`login.html`, `chat.js`)** — Ensures
  a fresh session doesn't reuse a previous user's cached data.
- **Remove duplicate `clearTemplatesCache` (`chat.js`)** — A duplicate call was
  shadowing the localStorage clear.
