### PR TITLE
fix(security): escape DOM-sourced date inputs in evals time range (CodeQL #6)

### DIFF
--- a/chatapp/app/templates/admin/evaluations.html
+++ b/chatapp/app/templates/admin/evaluations.html
@@ -255,8 +255,14 @@
     function applyCustomRange() {
         const start = document.getElementById('start-date').value;
         const end = document.getElementById('end-date').value;
-        if (start && end) {
-            window.location.href = `/admin/evaluations?start_time=${start}T00:00:00&end_time=${end}T23:59:59`;
+        // Validate inputs are plain YYYY-MM-DD dates, then URL-encode before
+        // building the navigation URL. This prevents untrusted DOM text from
+        // injecting URL/HTML meta-characters (CodeQL js/xss-through-dom).
+        const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+        if (dateRe.test(start) && dateRe.test(end)) {
+            const startParam = encodeURIComponent(`${start}T00:00:00`);
+            const endParam = encodeURIComponent(`${end}T23:59:59`);
+            window.location.href = `/admin/evaluations?start_time=${startParam}&end_time=${endParam}`;
         }
     }
 


### PR DESCRIPTION
## Summary 

Resolves CodeQL alert #6 (`js/xss-through-dom`, warning) in `chatapp/app/templates/admin/evaluations.html`. The `applyCustomRange()` function read the custom date-range values directly from the DOM (`#start-date.value`, `#end-date.value`) and concatenated them into `window.location.href` without escaping. CodeQL treats DOM text as untrusted, so unescaped meta-characters could flow into the navigation sink. 

## Fix 
- Validate both inputs against a strict `^\d{4}-\d{2}-\d{2}$` pattern before use (defense in depth). - URL-encode the values with `encodeURIComponent` before building the URL. 

## Risk 
Low. Admin-only page; the inputs are `<input type="date">` fields, so legitimate values are unaffected. No behavior change for valid dates. 

## Testing 
- [ ] Apply a custom date range in the evals dashboard and confirm navigation/filtering still works. 
- [ ] Confirm CodeQL re-scan clears alert #6 after merge.