### PR TITLE
Evals grounding, model catalog, episodic memory, and admin auth fixes

### DIFF
--- a/agent/my_agent.py
+++ b/agent/my_agent.py
@@ -1,4 +1,5 @@
 """AgentCore agent with memory support."""
+import json
 import os
 import time
 from bedrock_agentcore import BedrockAgentCoreApp
@@ -351,12 +352,21 @@ async def invoke(payload, context):
                                 tool_id = tool_result.get('toolUseId')
                                 if tool_id:
                                     log.info(f"Tool result for: {tool_id}")
-                                    # Extract text from result content
-                                    result_text = ''
+                                    # Capture ALL content blocks (text and json),
+                                    # not just the first text block. Tools that
+                                    # return structured data (e.g. the weather
+                                    # tool's dict) surface as a json block; only
+                                    # reading text dropped that data from the UI
+                                    # and from evaluation grounding.
+                                    result_parts = []
                                     for result_content in tool_result.get('content', []):
                                         if 'text' in result_content:
-                                            result_text = result_content['text']
-                                            break
+                                            result_parts.append(result_content['text'])
+                                        elif 'json' in result_content:
+                                            result_parts.append(
+                                                json.dumps(result_content['json'], default=str)
+                                            )
+                                    result_text = '\n'.join(result_parts)
                                     yield {
                                         "type": "tool_result",
                                         "tool_name": tool_id,

--- a/cdk/destroy-all.sh
+++ b/cdk/destroy-all.sh
@@ -222,24 +222,61 @@ echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━�
 
 # Note: ECR repositories are now managed by CDK and deleted automatically
 
-# Clean up CloudWatch log groups that may have been created outside CDK
+# Delete the ECS Express Gateway service.
+# CloudFormation deletion of AWS::ECS::ExpressGatewayService does not always
+# remove the underlying service, and a leftover service blocks a future
+# redeploy with: "Resource of type 'AWS::ECS::ExpressGatewayService' ...
+# already exists." So delete it explicitly here.
+echo -e "${YELLOW}Cleaning up ECS Express Gateway service...${NC}"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${CYAN}[DRY RUN] Would delete ECS Express Gateway service '${APP_NAME}-express' if present${NC}"
+else
+    EXPRESS_SVC_ARN=$(aws ecs list-services \
+        --cluster default \
+        --region "$AWS_REGION" \
+        --query "serviceArns[?contains(@, '${APP_NAME}-express')]" \
+        --output text 2>/dev/null | head -1 || echo "")
+    if [ -n "$EXPRESS_SVC_ARN" ] && [ "$EXPRESS_SVC_ARN" != "None" ]; then
+        aws ecs delete-express-gateway-service \
+            --service-arn "$EXPRESS_SVC_ARN" \
+            --region "$AWS_REGION" >/dev/null 2>&1 \
+            && echo -e "${GREEN}Deleted ECS Express Gateway service: ${EXPRESS_SVC_ARN}${NC}" \
+            || echo -e "${YELLOW}Could not delete express service (may already be gone): ${EXPRESS_SVC_ARN}${NC}"
+    else
+        echo -e "${GREEN}No ECS Express Gateway service found to delete${NC}"
+    fi
+fi
+
+# Clean up CloudWatch log groups left behind by deleted stacks.
+# CDK-declared log groups and Lambda-auto-created log groups can survive a
+# stack delete; if they have fixed names they then block a future deploy's
+# change set (e.g. /aws/lambda/${APP_NAME}-ecs-build-waiter-provider). All
+# stacks are already destroyed at this point, so prefix-based bulk deletion
+# of app-owned groups is safe.
 echo -e "${YELLOW}Cleaning up CloudWatch log groups...${NC}"
 
-LOG_GROUPS=(
-    "/ecs/${APP_NAME}/${APP_NAME}-express"
+LOG_GROUP_PREFIXES=(
+    "/aws/lambda/${APP_NAME}"
+    "/ecs/${APP_NAME}"
+    "/aws/vendedlogs/bedrock-agentcore"
     "/aws/bedrock-agentcore/runtimes"
 )
 
-for LOG_GROUP in "${LOG_GROUPS[@]}"; do
+for PREFIX in "${LOG_GROUP_PREFIXES[@]}"; do
     if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}[DRY RUN] Would check and delete log group: $LOG_GROUP${NC}"
-    else
-        # Check if log group exists and delete it
-        if aws logs describe-log-groups --log-group-name-prefix "$LOG_GROUP" --region "$AWS_REGION" --query 'logGroups[0]' --output text 2>/dev/null | grep -q "$LOG_GROUP"; then
-            aws logs delete-log-group --log-group-name "$LOG_GROUP" --region "$AWS_REGION" 2>/dev/null || true
-            echo -e "${GREEN}Deleted log group: $LOG_GROUP${NC}"
-        fi
+        echo -e "${CYAN}[DRY RUN] Would delete log groups with prefix: $PREFIX${NC}"
+        continue
     fi
+    LOG_GROUP_NAMES=$(aws logs describe-log-groups \
+        --log-group-name-prefix "$PREFIX" \
+        --region "$AWS_REGION" \
+        --query 'logGroups[].logGroupName' \
+        --output text 2>/dev/null || echo "")
+    for LOG_GROUP in $LOG_GROUP_NAMES; do
+        [ -z "$LOG_GROUP" ] && continue
+        aws logs delete-log-group --log-group-name "$LOG_GROUP" --region "$AWS_REGION" 2>/dev/null \
+            && echo -e "${GREEN}Deleted log group: $LOG_GROUP${NC}" || true
+    done
 done
 
 # Clean up CDK outputs file

--- a/cdk/lib/bedrock-stack.ts
+++ b/cdk/lib/bedrock-stack.ts
@@ -360,6 +360,19 @@ export class BedrockStack extends cdk.Stack {
             namespaces: ['/users/{actorId}/facts'],
           },
         },
+        {
+          // Episodic strategy - consolidates interactions into structured
+          // episodes (situation/intent/assessment/...). Namespace must match
+          // the chatapp read path in app/agentcore/memory.py (get_episodic):
+          // /episodes/{actorId}/{sessionId}/
+          episodicMemoryStrategy: {
+            name: 'EpisodicMemory',
+            namespaces: ['/episodes/{actorId}/{sessionId}/'],
+            reflectionConfiguration: {
+              namespaces: ['/episodes/{actorId}/'],
+            },
+          },
+        },
       ],
       
       // Tags

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20.19.0",
-        "aws-cdk": "^2.1108.0",
+        "aws-cdk": "^2.1128.0",
         "cdk-nag": "^2.37.55",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6",
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1108.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1108.0.tgz",
-      "integrity": "sha512-FHnyhnYZoRc2W0C9mNzhNn6fO2vH4xNINsKfJaA7AFDuymgQ39JhEnrM4AHaoikIBqXYeNLWElvvkusY9l3ulw==",
+      "version": "2.1128.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1128.0.tgz",
+      "integrity": "sha512-CXPl6Yu0gDqrS2GYDPoMCQbdJFS0tupzN8nuaTku3fewTdQJhHGK/2QpwMV/mVgsTTHB9riXT3Zt/k4trh8tCw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^20.19.0",
-    "aws-cdk": "^2.1108.0",
+    "aws-cdk": "^2.1128.0",
     "cdk-nag": "^2.37.55",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6",

--- a/chatapp/app/admin/cost_calculator.py
+++ b/chatapp/app/admin/cost_calculator.py
@@ -6,18 +6,13 @@ based on token usage and model pricing rates.
 
 from typing import Dict
 
+from app.helpers.model_catalog import get_pricing
 
-# Model pricing in USD per 1 million tokens
+
+# Model pricing in USD per 1 million tokens, sourced from the single
+# source of truth at app/static/models.json (shared with the front-end).
 # Format: {"model_id": {"input": rate, "output": rate}}
-MODEL_PRICING: Dict[str, Dict[str, float]] = {
-    "global.amazon.nova-2-lite-v1:0": {"input": 0.30, "output": 2.50},
-    "us.amazon.nova-pro-v1:0": {"input": 0.80, "output": 3.20},
-    "global.anthropic.claude-haiku-4-5-20251001-v1:0": {"input": 1.00, "output": 5.00},
-    "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {"input": 3.00, "output": 15.00},
-    "global.anthropic.claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
-    "global.anthropic.claude-opus-4-5-20251101-v1:0": {"input": 5.00, "output": 25.00},
-    "global.anthropic.claude-opus-4-6-v1": {"input": 5.00, "output": 25.00},
-}
+MODEL_PRICING: Dict[str, Dict[str, float]] = get_pricing()
 
 # Default pricing for unknown models
 DEFAULT_PRICING = {"input": 0.00, "output": 0.00}

--- a/chatapp/app/agentcore/memory.py
+++ b/chatapp/app/agentcore/memory.py
@@ -55,6 +55,43 @@ def _format_event_content(raw_text, default_role):
 logger = logging.getLogger(__name__)
 
 
+def _format_event_content(raw_text, default_role):
+    """Unwrap a stored Strands message envelope into (role, display_text).
+
+    Some agents (for example a multi-agent orchestrator) persist the full
+    message object as the event text, e.g.:
+        {"message": {"role": "assistant", "content": [{"text": "..."},
+                                                       {"toolUse": {...}}]}, ...}
+    This returns the message's real role plus the concatenated human-readable
+    text blocks (tool-use / tool-result blocks are dropped, so the conversation
+    history shows clean narration instead of raw JSON). Plain-text events are
+    returned unchanged.
+    """
+    if not raw_text or not isinstance(raw_text, str):
+        return default_role, raw_text or ""
+    if not raw_text.lstrip().startswith("{"):
+        return default_role, raw_text
+    try:
+        obj = json.loads(raw_text)
+    except (ValueError, TypeError):
+        return default_role, raw_text
+    if not isinstance(obj, dict) or not isinstance(obj.get("message"), dict):
+        return default_role, raw_text
+    msg = obj["message"]
+    role = msg.get("role", default_role)
+    role = role.lower() if isinstance(role, str) else default_role
+    content = msg.get("content")
+    if isinstance(content, str):
+        return role, content
+    if not isinstance(content, list):
+        return role, raw_text
+    texts = [
+        b["text"] for b in content
+        if isinstance(b, dict) and isinstance(b.get("text"), str)
+    ]
+    return role, "\n\n".join(texts).strip()
+
+
 @dataclass
 class MemoryEvent:
     """Event memory record from conversation history.
@@ -84,6 +121,20 @@ class SemanticFact:
     fact_id: str
     content: str
     confidence: Optional[float]
+    timestamp: str
+
+
+@dataclass
+class EpisodicMemory:
+    """Episodic memory record capturing a structured interaction episode.
+
+    Attributes:
+        episode_id: Unique identifier for the episode
+        content: Episode content (scenario, intent, actions, outcome, etc.)
+        timestamp: When the episode was recorded
+    """
+    episode_id: str
+    content: str
     timestamp: str
 
 
@@ -184,8 +235,10 @@ class MemoryClient:
                         content_obj = conv.get('content', {})
                         text = content_obj.get('text', '')
 
-                        # Unwrap Strands message envelopes so the
-                        # Events panel shows clean text, not raw JSON.
+                        # Unwrap stored Strands message envelopes so the UI
+                        # shows clean role + text instead of raw JSON. Pure
+                        # tool-use/tool-result turns yield empty text and are
+                        # skipped by the `if text:` guard below.
                         role, text = _format_event_content(text, role)
 
                         if text:
@@ -376,6 +429,116 @@ class MemoryClient:
         except Exception as e:
             logger.error(
                 "Unexpected error fetching semantic memory",
+                extra={
+                    "session_id": session_id,
+                    "user_id": user_id,
+                    "error": str(e),
+                }
+            )
+            return []
+
+    async def get_episodic(
+        self,
+        session_id: str,
+        user_id: str,
+        max_results: int = 50,
+    ) -> List[EpisodicMemory]:
+        """Fetch episodic memory (structured interaction episodes) for a session.
+
+        Args:
+            session_id: Session ID for the conversation
+            user_id: User ID for memory lookup
+            max_results: Maximum number of records to return
+
+        Returns:
+            List of EpisodicMemory objects
+
+        Note:
+            Errors are logged but return empty list to avoid affecting chat
+        """
+        if not self.memory_id:
+            logger.info("Memory ID not configured, returning empty episodic memory")
+            return []
+
+        try:
+            logger.info(
+                "Fetching episodic memory",
+                extra={
+                    "session_id": session_id,
+                    "user_id": user_id,
+                    "memory_id": self.memory_id,
+                }
+            )
+
+            # Namespace matches CDK config: /episodes/{actorId}/{sessionId}/
+            namespace = f"/episodes/{user_id}/{session_id}/"
+
+            response = self._client.list_memory_records(
+                memoryId=self.memory_id,
+                namespace=namespace,
+                maxResults=max_results,
+            )
+
+            episodes: List[EpisodicMemory] = []
+
+            for record in response.get('memoryRecordSummaries', []):
+                content_obj = record.get('content', {})
+                text = content_obj.get('text', '')
+
+                if text:
+                    created_at = record.get('createdAt')
+                    if created_at:
+                        if isinstance(created_at, datetime):
+                            created_at = created_at.isoformat()
+                        elif not isinstance(created_at, str):
+                            created_at = str(created_at)
+                    else:
+                        created_at = datetime.utcnow().isoformat()
+
+                    episodes.append(EpisodicMemory(
+                        episode_id=record.get('memoryRecordId', ''),
+                        content=text,
+                        timestamp=created_at,
+                    ))
+
+            episodes.sort(key=lambda e: e.timestamp, reverse=True)
+
+            logger.info(
+                "Episodic memory fetched successfully",
+                extra={
+                    "session_id": session_id,
+                    "episode_count": len(episodes),
+                }
+            )
+
+            return episodes
+
+        except ClientError as e:
+            error_code = e.response.get('Error', {}).get('Code', 'Unknown')
+            error_message = str(e)
+            if error_code in ('ResourceNotFoundException', 'NotFoundException', 'ValidationException') or 'not found' in error_message.lower():
+                logger.debug(
+                    "No episodic memory found (new session)",
+                    extra={
+                        "session_id": session_id,
+                        "user_id": user_id,
+                        "error_code": error_code,
+                    }
+                )
+            else:
+                logger.warning(
+                    f"Failed to fetch episodic memory (error_code={error_code})",
+                    extra={
+                        "session_id": session_id,
+                        "user_id": user_id,
+                        "error_code": error_code,
+                        "error": error_message,
+                    }
+                )
+            return []
+        except Exception as e:
+            logger.error(
+                "Unexpected error fetching episodic memory",
                 extra={
                     "session_id": session_id,
                     "user_id": user_id,

--- a/chatapp/app/auth/cognito.py
+++ b/chatapp/app/auth/cognito.py
@@ -9,7 +9,7 @@ import hashlib
 import hmac
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 import boto3
@@ -69,10 +69,13 @@ class UserInfo:
         user_id: The unique user identifier (sub claim)
         email: User's email address
         username: Cognito username
+        groups: Cognito group memberships from the verified token's
+            'cognito:groups' claim (empty if the user is in no groups)
     """
     user_id: str
     email: Optional[str] = None
     username: Optional[str] = None
+    groups: list[str] = field(default_factory=list)
 
 
 class CognitoAuth:
@@ -338,6 +341,12 @@ class CognitoAuth:
             user_id = claims.get("sub")
             if not user_id:
                 raise TokenValidationError("Token missing 'sub' claim")
+
+            # Group membership comes from the verified token's 'cognito:groups'
+            # claim (Cognito adds it to access and ID tokens for users in any
+            # group). Reading it here means admin status needs no per-request
+            # Cognito API call and cannot be spoofed via the session cookie.
+            groups = list(claims.get("cognito:groups") or [])
             
             # If ID token provided, verify and extract richer user info
             email = None
@@ -356,6 +365,8 @@ class CognitoAuth:
                     )
                     email = id_claims.get("email")
                     username = id_claims.get("cognito:username") or email
+                    if not groups:
+                        groups = list(id_claims.get("cognito:groups") or [])
                 except Exception as e:
                     logger.warning(f"Failed to verify ID token: {e}")
                     # Fall back to unverified claims for email (non-critical)
@@ -370,6 +381,7 @@ class CognitoAuth:
                 user_id=user_id,
                 email=email,
                 username=username,
+                groups=groups,
             )
             
         except ExpiredSignatureError:
@@ -402,29 +414,6 @@ def extract_user_id(token: str) -> str:
         raise
     except Exception as e:
         raise TokenValidationError(f"Invalid token: {str(e)}")
-
-
-async def get_user_groups(username: str) -> list[str]:
-    """Get the groups a user belongs to in Cognito.
-    
-    Args:
-        username: The user's username (email)
-        
-    Returns:
-        List of group names the user belongs to
-    """
-    config = get_config()
-    client = boto3.client('cognito-idp', region_name=config.aws_region)
-    
-    try:
-        response = client.admin_list_groups_for_user(
-            UserPoolId=config.cognito_user_pool_id,
-            Username=username,
-        )
-        return [group['GroupName'] for group in response.get('Groups', [])]
-    except ClientError as e:
-        logger.warning(f"Failed to get groups for user {username}: {e}")
-        return []
 
 
 def is_admin(groups: list[str]) -> bool:

--- a/chatapp/app/auth/middleware.py
+++ b/chatapp/app/auth/middleware.py
@@ -18,7 +18,6 @@ from app.auth.cognito import (
     TokenExpiredError,
     TokenValidationError,
     UserInfo,
-    get_user_groups,
     is_admin,
 )
 from app.config import get_config
@@ -97,6 +96,41 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return True
         return False
 
+    def _apply_authorization(
+        self,
+        request: Request,
+        user_info: UserInfo,
+        is_api: bool,
+    ) -> Optional[Response]:
+        """Resolve admin status and enforce admin-route access.
+
+        Sets ``request.state.is_admin`` (consumed by templates to show/hide the
+        admin UI) from the verified token's group membership
+        (``user_info.groups``, sourced from the ``cognito:groups`` claim). No
+        per-request Cognito API call is made, and the value cannot be spoofed via
+        the session cookie because it comes from the signed token.
+
+        This MUST run on BOTH the normal auth path and the token-refresh path.
+        If only the normal path sets it, a request that triggers a token refresh
+        (e.g. the first page load after the access token expires during
+        inactivity) renders with is_admin unset — the admin button disappears
+        until the next reload, and admin-route authorization is skipped.
+
+        Returns:
+            A forbidden Response if the route requires admin and the user is not
+            an admin; otherwise None.
+        """
+        request.state.is_admin = is_admin(user_info.groups or [])
+        logger.info(
+            f"Auth check: user={user_info.username or user_info.email}, "
+            f"is_admin={request.state.is_admin}, groups={user_info.groups}, "
+            f"path={request.url.path}"
+        )
+
+        if self._is_admin_route(request.url.path) and not request.state.is_admin:
+            return self._handle_forbidden(request, is_api)
+        return None
+
     async def dispatch(
         self, request: Request, call_next: Callable
     ) -> Response:
@@ -153,33 +187,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # Attach user info to request state
             request.state.user = user_info
             request.state.session = session_data
-            
-            # Get user groups (fetch fresh each time - don't cache in cookie to avoid size issues)
-            user_groups = []
-            username_for_groups = user_info.username or user_info.email or session_data.get("username")
-            logger.debug(f"Group lookup: username={user_info.username}, email={user_info.email}, session_username={session_data.get('username')}, using={username_for_groups}")
-            
-            if username_for_groups:
-                try:
-                    user_groups = await get_user_groups(username_for_groups)
-                    logger.debug(f"Fetched groups for {username_for_groups}: {user_groups}")
-                except Exception as e:
-                    # Failed to fetch groups - log the error and default to no groups
-                    logger.error(f"Failed to fetch groups for {username_for_groups}: {e}", exc_info=True)
-                    user_groups = []
-            else:
-                logger.warning(f"No username available for group lookup (user_id={user_info.user_id})")
-            
-            # Set is_admin flag for all routes (used by templates)
-            is_admin_user = is_admin(user_groups or [])
-            request.state.is_admin = is_admin_user
-            logger.info(f"Auth check: user={user_info.username or user_info.email}, is_admin={is_admin_user}, groups={user_groups}, path={request.url.path}")
-            
-            # Check admin authorization for admin routes
-            if self._is_admin_route(request.url.path):
-                if not request.state.is_admin:
-                    return self._handle_forbidden(request, is_api)
-            
+
+            # Resolve admin status and enforce admin-route authorization.
+            forbidden = self._apply_authorization(request, user_info, is_api)
+            if forbidden is not None:
+                return forbidden
+
             return await call_next(request)
             
         except TokenExpiredError:
@@ -360,7 +373,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
             
             # Store new refresh token in request state
             request.state.refresh_token = token_response.refresh_token or refresh_token
-            
+
+            # Resolve admin status and enforce admin-route authorization on the
+            # refresh path too, so the admin UI does not vanish (and admin routes
+            # are not left unguarded) on the first request after token expiry.
+            forbidden = self._apply_authorization(request, user_info, is_api)
+            if forbidden is not None:
+                return forbidden
+
             # Continue with the request
             response = await call_next(request)
             

--- a/chatapp/app/evaluations/capabilities.py
+++ b/chatapp/app/evaluations/capabilities.py
@@ -1,0 +1,38 @@
+"""Ground-truth manifest of the agent's real capabilities.
+
+Used to ground LLM-as-judge evaluators so they do not penalize the agent for
+truthfully describing tools it actually has. Without this, a judge with no
+knowledge of the agent's tool set assumes capability claims (weather, URL
+fetching, web search, etc.) are hallucinated and fails otherwise-correct
+answers.
+
+IMPORTANT: This MUST be kept in sync with the agent definition in
+agent/my_agent.py (its `tools` list and `system_prompt`). The chatapp and the
+agent are deployed separately, so this cannot be imported from the agent
+package and is intentionally duplicated here.
+"""
+
+# Mirrors agent/my_agent.py: tools list + system prompt capability statements.
+AGENT_CAPABILITIES_MANIFEST = """\
+The assistant is a helpful AI assistant with per-session conversation memory \
+(it can remember earlier messages within the same session).
+
+The assistant has access to the following tools and may truthfully describe \
+any of them as its own capabilities:
+- search_knowledge_base: search a curated, domain-specific Knowledge Base. \
+This is the preferred first source and is checked before web tools.
+- ddg_web_search: perform a DuckDuckGo web search for current or general \
+internet information.
+- fetch_url_content: fetch and read the content of a specific URL / webpage.
+- calculator: a symbolic math engine (sympy-backed). Beyond basic arithmetic \
+it supports equation solving, derivatives (including higher-order), indefinite \
+integrals, limits, Taylor/Laurent series expansions, and matrix operations.
+- get_current_weather: look up current weather for US locations.
+- current_time: get the current date and time for any named timezone \
+(e.g., UTC, US/Pacific, Europe/London, Asia/Tokyo), defaulting to UTC.
+
+Statements by the assistant that describe any of the above capabilities are \
+ACCURATE and must NOT be treated as hallucinations or false claims. Only treat \
+capability claims as a problem when they contradict this list or go beyond it \
+(for example, claiming to send email, book travel, or run code).\
+"""

--- a/chatapp/app/evaluations/engine.py
+++ b/chatapp/app/evaluations/engine.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 
 from app.evaluations.config import EvalConfig
+from app.evaluations.capabilities import AGENT_CAPABILITIES_MANIFEST
 from app.evaluations.evaluators import (
     EvalResult,
     ToolSelectionEvaluator,
@@ -37,12 +38,27 @@ _tool_selection_evaluator = ToolSelectionEvaluator()
 # Binary rubrics for LLM-as-judge evaluators. Each asks for a single
 # yes/no judgment with an explicit pass criterion (not a 0-5 scale).
 ANSWER_QUALITY_RUBRIC = """\
-Decide whether the assistant's response is a good answer to the user's question.
+Decide whether the assistant's response is a good answer to the user's latest
+message.
+
+You are given a description of the assistant's actual capabilities (the tools it
+really has). Treat it as ground truth: if the response describes capabilities
+that match this list, those statements are ACCURATE and must NOT be penalized as
+false or misleading. Only treat capability claims as a problem when they
+contradict the listed capabilities or go beyond them.
+
+The user's latest message may be a short follow-up (e.g. "yes", "do it", "the
+second one") that only makes sense in light of the conversation so far. When
+prior conversation is provided, interpret the latest message in that context;
+do NOT penalize the response for addressing the established topic rather than the
+literal words of the latest message.
 
 A response PASSES only if ALL of the following hold:
-- It directly addresses what the user actually asked.
+- It addresses what the user actually asked, interpreted in light of the
+  conversation so far.
 - It is complete enough to be useful (no major missing pieces).
 - It is clear and on-topic (no significant irrelevant content).
+- It does not misrepresent the assistant's actual capabilities.
 
 Set test_pass to true and score to 1.0 if the response PASSES.
 Set test_pass to false and score to 0.0 if it FAILS any criterion.
@@ -122,6 +138,45 @@ def _run_binary_judge(
         return None
 
 
+def _build_grounded_context(context_items: List[str], max_total: int) -> str:
+    """Join tool/KB results into one grounding block within a char budget.
+
+    Allocates the budget fairly across results so a few large results (e.g. a
+    fetched web page or web-search dump) cannot starve later ones (e.g. a
+    weather tool result that happened to run last). Without this, a blind
+    `joined[:max_total]` truncation drops the tail, causing faithfulness false
+    negatives when the response is grounded in a late tool call.
+
+    Strategy: process shortest results first so small ones are kept whole, and
+    redistribute the freed budget to larger results. Output preserves the
+    original call order, and truncated results are marked so the judge knows
+    the source was cut rather than absent.
+    """
+    items = [i for i in context_items if i and i.strip()]
+    if not items:
+        return ""
+
+    budgets = [0] * len(items)
+    remaining = max_total
+    slots = len(items)
+    for idx in sorted(range(len(items)), key=lambda i: len(items[i])):
+        share = remaining // slots if slots else 0
+        take = min(len(items[idx]), share)
+        budgets[idx] = take
+        remaining -= take
+        slots -= 1
+
+    parts = []
+    for i, item in enumerate(items):
+        if budgets[i] <= 0:
+            continue
+        if budgets[i] < len(item):
+            parts.append(item[:budgets[i]] + " …[truncated]")
+        else:
+            parts.append(item)
+    return "\n\n".join(parts)
+
+
 async def run_evaluations(
     user_input: str,
     agent_output: str,
@@ -131,7 +186,8 @@ async def run_evaluations(
     tool_usage: Optional[Dict[str, Dict[str, int]]] = None,
     input_tokens: int = 0,
     output_tokens: int = 0,
-    context: Optional[str] = None,
+    context_items: Optional[List[str]] = None,
+    conversation_history: Optional[str] = None,
 ) -> None:
     """Run all enabled evaluations asynchronously and store results.
 
@@ -147,8 +203,13 @@ async def run_evaluations(
         tool_usage: Dict of tool_name -> usage counts
         input_tokens: Input tokens consumed (operational; not evaluated here)
         output_tokens: Output tokens generated (operational; not evaluated here)
-        context: Retrieved source material (tool/KB results) used in the turn,
-            required for faithfulness evaluation
+        context_items: Retrieved source material as a list of individual
+            tool/KB results (one string per tool call), required for
+            faithfulness. Passed as a list (not a pre-joined string) so the
+            budget can be allocated fairly across results.
+        conversation_history: Prior turns of the conversation (a plain-text
+            transcript), used so judges can interpret follow-up messages like
+            "yes" that only make sense in context. Optional.
     """
     config = EvalConfig.from_env()
 
@@ -189,18 +250,45 @@ async def run_evaluations(
     llm_tasks = []
     if run_llm:
         if "answer_quality" in config.llm_evaluators:
+            # Ground the judge with the agent's real capabilities so it does not
+            # flag truthful tool/capability claims as hallucinations, and with
+            # prior turns so follow-ups like "yes" are interpreted in context.
+            history_block = (
+                f"Conversation so far (prior turns, for context):\n"
+                f"{conversation_history}\n\n"
+                if conversation_history else ""
+            )
+            answer_quality_input = (
+                f"Assistant's actual capabilities:\n{AGENT_CAPABILITIES_MANIFEST}\n\n"
+                f"{history_block}"
+                f"User's latest message:\n{user_input}"
+            )
             llm_tasks.append(("answer_quality", loop.run_in_executor(
                 None, _run_binary_judge,
-                ANSWER_QUALITY_RUBRIC, user_input, agent_output, config,
+                ANSWER_QUALITY_RUBRIC, answer_quality_input, agent_output, config,
             )))
 
         # Faithfulness only makes sense when there is source material to
         # ground against. Skip it for turns that used no tools/KB.
-        if "faithfulness" in config.llm_evaluators and context and context.strip():
+        grounded_context = _build_grounded_context(
+            context_items or [], config.max_context_length
+        )
+        if "faithfulness" in config.llm_evaluators and grounded_context:
+            # Include the capability manifest alongside retrieved context so
+            # truthful capability statements are also treated as grounded, plus
+            # prior turns so the judge can interpret follow-up messages.
+            history_block = (
+                f"Conversation so far (prior turns, for context):\n"
+                f"{conversation_history}\n\n"
+                if conversation_history else ""
+            )
             faithfulness_input = (
-                f"User question:\n{user_input}\n\n"
-                f"Source material (retrieved context and tool results):\n"
-                f"{context[:config.max_context_length]}"
+                f"{history_block}"
+                f"User's latest message:\n{user_input}\n\n"
+                f"Source material (assistant capabilities, retrieved context, "
+                f"and tool results):\n"
+                f"{AGENT_CAPABILITIES_MANIFEST}\n\n"
+                f"{grounded_context}"
             )
             llm_tasks.append(("faithfulness", loop.run_in_executor(
                 None, _run_binary_judge,

--- a/chatapp/app/evaluations/evaluators.py
+++ b/chatapp/app/evaluations/evaluators.py
@@ -5,7 +5,6 @@ Content safety is handled by Amazon Bedrock Guardrails, not here.
 """
 
 import logging
-import re
 from dataclasses import dataclass
 from typing import Dict, Any, List, Optional
 
@@ -35,28 +34,9 @@ class ToolSelectionEvaluator:
     unnecessary tool calls based on the user's query.
     """
 
-    # Keywords that suggest specific tools should be used
-    TOOL_HINTS = {
-        "calculator": [
-            r'\b(?:calculate|compute|math|sum|add|subtract|multiply|divide|percentage|%)\b',
-            r'\b\d+\s*[\+\-\*\/\%]\s*\d+\b',
-        ],
-        "current_time": [
-            r'\b(?:time|date|today|now|clock|day of week)\b',
-        ],
-        "get_current_weather": [
-            r'\b(?:weather|temperature|forecast|rain|snow|sunny|cloudy)\b',
-        ],
-        "ddg_web_search": [
-            r'\b(?:search|look up|find|google|latest|recent|news)\b',
-        ],
-        "search_knowledge_base": [
-            r'\b(?:knowledge base|documentation|docs|internal|curated)\b',
-        ],
-        "fetch_url_content": [
-            r'\b(?:url|link|website|webpage|http|https)\b',
-        ],
-    }
+    # A turn passes if its computed tool-selection quality meets this bar.
+    # Quality is computed internally only to derive Pass/Fail; it is not shown.
+    PASS_THRESHOLD = 0.5
 
     def evaluate(
         self,
@@ -65,62 +45,47 @@ class ToolSelectionEvaluator:
         tools_used: Dict[str, Dict[str, int]],
     ) -> EvalResult:
         """Evaluate tool selection quality.
-        
+
+        Judges only what can be measured reliably from execution: whether the
+        tools the agent actually invoked succeeded and were used efficiently.
+
+        It deliberately does NOT guess which tools "should" have been used from
+        the wording of the query. Keyword-based intent guessing produces false
+        negatives (e.g. expecting current_time just because the word "today"
+        appears), penalizing the agent for correctly skipping an unneeded tool.
+
         Args:
-            user_input: The user's message
-            agent_output: The agent's response text
+            user_input: The user's message (unused; kept for interface parity)
+            agent_output: The agent's response text (unused)
             tools_used: Dict of tool_name -> {call_count, success_count, error_count}
-            
+
         Returns:
             EvalResult with tool selection assessment
         """
         if not tools_used:
-            # No tools used - check if tools should have been used
-            expected = self._get_expected_tools(user_input)
-            if expected:
-                return EvalResult(
-                    score=0.5,
-                    passed=True,
-                    label="Possibly missed tools",
-                    reason=f"No tools used, but query may have benefited from: {', '.join(expected)}",
-                )
+            # No tools were used. Without reliable intent detection we do not
+            # second-guess that decision, so it passes.
             return EvalResult(
                 score=1.0,
                 passed=True,
-                label="Appropriate (no tools needed)",
-                reason="No tools used and none appeared necessary",
+                label="Pass",
+                reason="No tools used",
             )
 
         used_names = set(tools_used.keys())
-        expected = set(self._get_expected_tools(user_input))
 
-        # Calculate metrics
         total_calls = sum(t.get("call_count", 0) for t in tools_used.values())
         total_errors = sum(t.get("error_count", 0) for t in tools_used.values())
         error_rate = total_errors / total_calls if total_calls > 0 else 0
 
-        # Score components
-        scores = []
-
-        # 1. Were expected tools used?
-        if expected:
-            overlap = used_names & expected
-            expected_score = len(overlap) / len(expected) if expected else 1.0
-            scores.append(expected_score)
-
-        # 2. Error rate penalty
+        # Quality components for tools that were actually invoked. Take the
+        # weakest signal (min), not the average, so a high error rate cannot be
+        # masked by otherwise-efficient usage.
         error_score = 1.0 - error_rate
-        scores.append(error_score)
-
-        # 3. Efficiency - penalize excessive tool calls (>5 is suspicious)
         efficiency_score = min(1.0, 5.0 / total_calls) if total_calls > 5 else 1.0
-        scores.append(efficiency_score)
-
-        avg_score = sum(scores) / len(scores) if scores else 1.0
+        quality = min(error_score, efficiency_score)
 
         reasons = []
-        if expected and not (used_names & expected):
-            reasons.append(f"Expected tools not used: {', '.join(expected - used_names)}")
         if error_rate > 0:
             reasons.append(f"Tool error rate: {error_rate:.0%}")
         if total_calls > 5:
@@ -128,22 +93,11 @@ class ToolSelectionEvaluator:
         if not reasons:
             reasons.append(f"Tools used appropriately: {', '.join(used_names)}")
 
-        label = "Good" if avg_score >= 0.7 else ("Fair" if avg_score >= 0.4 else "Poor")
+        passed = quality >= self.PASS_THRESHOLD
 
         return EvalResult(
-            score=round(avg_score, 3),
-            passed=avg_score >= 0.5,
-            label=label,
+            score=1.0 if passed else 0.0,
+            passed=passed,
+            label="Pass" if passed else "Fail",
             reason="; ".join(reasons),
         )
-
-    def _get_expected_tools(self, user_input: str) -> List[str]:
-        """Determine which tools the query likely needs."""
-        expected = []
-        input_lower = user_input.lower()
-        for tool_name, patterns in self.TOOL_HINTS.items():
-            for pattern in patterns:
-                if re.search(pattern, input_lower):
-                    expected.append(tool_name)
-                    break
-        return expected

--- a/chatapp/app/helpers/model_catalog.py
+++ b/chatapp/app/helpers/model_catalog.py
@@ -1,0 +1,64 @@
+"""Shared model catalog loader.
+
+Reads the single source of truth at ``app/static/models.json`` (the same file the
+browser uses via ``/static/models.json``) so model ids, display names, and
+pricing are defined in exactly one place for both Python and JavaScript.
+
+Consumers:
+  * ``admin/cost_calculator.py`` — pricing (USD per 1M input/output tokens)
+  * ``templates_config`` — injects the catalog as a template global so the
+    front-end (``static/js/chat.js``) reads the very same data.
+"""
+
+import json
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+_CATALOG_PATH = Path(__file__).resolve().parent.parent / "static" / "models.json"
+
+# Used when the catalog file is missing/unreadable so callers never crash.
+_FALLBACK = {"default_model_id": "", "models": []}
+
+
+@lru_cache(maxsize=1)
+def load_catalog() -> dict:
+    """Load and cache the model catalog JSON. Never raises."""
+    try:
+        with open(_CATALOG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data.get("models"), list):
+            raise ValueError("models.json missing 'models' list")
+        return data
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not load model catalog from %s: %s", _CATALOG_PATH, e)
+        return _FALLBACK
+
+
+def get_models() -> List[dict]:
+    """List of model dicts: {id, name, input, output}."""
+    return load_catalog().get("models", [])
+
+
+def default_model_id() -> str:
+    return load_catalog().get("default_model_id", "")
+
+
+def get_pricing() -> Dict[str, Dict[str, float]]:
+    """{model_id: {"input": rate, "output": rate}} per 1M tokens."""
+    return {
+        m["id"]: {"input": float(m.get("input", 0.0)), "output": float(m.get("output", 0.0))}
+        for m in get_models()
+        if m.get("id")
+    }
+
+
+def model_name(model_id: str) -> str:
+    """Friendly display name for a model id (falls back to the raw id)."""
+    for m in get_models():
+        if m.get("id") == model_id:
+            return m.get("name", model_id)
+    return model_id

--- a/chatapp/app/routes/chat.py
+++ b/chatapp/app/routes/chat.py
@@ -124,10 +124,14 @@ async def _stream_chat_response(
     user_email: str | None = None,
 ):
     """Generate SSE stream from AgentCore response.
-    
-    Accumulates metrics during stream and stores usage record asynchronously
-    after stream completes (fire-and-forget pattern per Requirements 2.1, 8.1).
-    
+
+    Accumulates metrics during the stream and stores the usage record
+    asynchronously (fire-and-forget) after the stream completes. Also runs
+    response evaluations fire-and-forget once the stream finishes.
+
+    Sends SSE comment keepalives every 15s while waiting for the next token so
+    a load balancer / proxy idle timeout never drops a long-running connection.
+
     Args:
         prompt: User message
         session_id: Session ID for conversation context
@@ -139,17 +143,13 @@ async def _stream_chat_response(
         SSE formatted event strings
     """
     client = AgentCoreClient()
-    
+
     # Accumulate metrics during stream
     accumulated_metrics: Dict[str, Any] = {}
     # Track tool usage from ToolUseEvents in the stream
     tool_usage_counts: Dict[str, Dict[str, int]] = {}
     # Track pending tool uses by ID to correlate with results
     pending_tool_uses: Dict[str, Dict[str, Any]] = {}
-    # Track whether last event was a tool result (for paragraph break injection)
-    after_tool = False
-    # Track last message content to avoid breaking mid-sentence
-    last_message_content = ""
     # Accumulate full agent output text for post-stream evaluation
     accumulated_output: list[str] = []
     # Accumulate tool/KB result content to ground the faithfulness evaluator
@@ -157,14 +157,18 @@ async def _stream_chat_response(
 
     # Keepalive via asyncio.Queue + producer task.
     #
-    # asyncio.wait_for() on an async generator's __anext__() is unsafe: when
-    # the timeout fires it cancels the coroutine and leaves the generator in a
-    # broken state. The safe pattern: run the generator in a separate task that
-    # pushes events onto a Queue. The consumer waits on the queue with a
-    # timeout; on timeout it yields an SSE comment (invisible to the browser,
-    # resets the ALB/proxy idle timer) and loops.
+    # asyncio.wait_for() on an async generator's __anext__() is unsafe: when the
+    # timeout fires it cancels the coroutine and leaves the generator in a
+    # broken state, causing a RuntimeError on the next iteration. That unhandled
+    # exception inside StreamingResponse makes uvicorn RST the HTTP/2 stream
+    # (ERR_HTTP2_PROTOCOL_ERROR 200).
+    #
+    # The safe pattern: run the generator in a separate task that pushes events
+    # onto a Queue. The consumer waits on the queue with a timeout; on timeout
+    # it yields an SSE comment (invisible to the browser, resets the idle timer)
+    # and loops. The generator task is never interrupted.
     KEEPALIVE_INTERVAL = 15  # seconds — well under typical 60s LB idle timeouts
-    _SENTINEL = object()
+    _SENTINEL = object()  # signals end-of-stream
     queue: asyncio.Queue = asyncio.Queue(maxsize=64)
 
     async def _producer():
@@ -188,6 +192,8 @@ async def _stream_chat_response(
         try:
             item = await asyncio.wait_for(queue.get(), timeout=KEEPALIVE_INTERVAL)
         except asyncio.TimeoutError:
+            # No event within the interval — send an SSE comment to reset the
+            # proxy/LB idle timer. Comments are ignored by EventSource clients.
             yield ": keepalive\n\n"
             continue
 
@@ -195,25 +201,17 @@ async def _stream_chat_response(
             break
 
         event = item
-        # Inject paragraph break when message text follows a tool result
-        # Only if previous text ended a sentence (avoid splitting "Here" / "'s a full overview")
-        if isinstance(event, MessageEvent) and after_tool and event.content.strip():
-            after_tool = False
-            if last_message_content and last_message_content.rstrip()[-1:] in '.!?\n':
-                yield MessageEvent(content="\n\n").to_sse_format()
-        
-        # Track last message content for sentence boundary detection and
-        # accumulate full output for evaluation after the stream completes
+
+        # Accumulate full output for post-stream evaluation.
+        # Tool/text separation (line breaks) is handled client-side in chat.js.
         if isinstance(event, MessageEvent) and event.content:
             accumulated_output.append(event.content)
-            if event.content.strip():
-                last_message_content = event.content
-        
+
         # Track tool usage from ToolUseEvent
         if isinstance(event, ToolUseEvent):
             tool_name = event.tool_name or "unknown"
             tool_use_id = event.tool_use_id
-            
+
             # Initialize tool in counts if needed
             if tool_name not in tool_usage_counts:
                 tool_usage_counts[tool_name] = {
@@ -221,59 +219,61 @@ async def _stream_chat_response(
                     "success_count": 0,
                     "error_count": 0,
                 }
-            
+
             # Track this tool use as pending (will be resolved when result arrives)
             pending_tool_uses[tool_use_id] = {
                 "tool_name": tool_name,
                 "status": "pending"
             }
             tool_usage_counts[tool_name]["call_count"] += 1
-            after_tool = True
 
         # Track tool results and update success/error counts
         elif isinstance(event, ToolResultEvent):
             tool_use_id = event.tool_use_id
-            
+
             # Find the corresponding tool use
             if tool_use_id in pending_tool_uses:
                 tool_info = pending_tool_uses.pop(tool_use_id)
                 tool_name = tool_info["tool_name"]
-                
-                # Determine if result indicates success or error (for usage stats only)
+
+                # Determine if result indicates success or error (usage stats only)
                 is_error = _is_error_result(event.tool_result, event.status)
-                
+
                 if is_error:
                     tool_usage_counts[tool_name]["error_count"] += 1
                 else:
                     tool_usage_counts[tool_name]["success_count"] += 1
 
-                # Capture the tool/KB output as grounding context for the
-                # faithfulness judge, regardless of the error heuristic. The
-                # heuristic does substring matching ("error", "cannot", ...)
-                # that misclassifies legitimate source text, so it must not
-                # gate what the judge sees.
-                if event.tool_result is not None:
-                    result_text = (
-                        event.tool_result
-                        if isinstance(event.tool_result, str)
-                        else json.dumps(event.tool_result, default=str)
-                    )
-                    accumulated_context.append(f"[{tool_name}] {result_text}")
-        
+            # Capture the tool/KB output as grounding context for the
+            # faithfulness judge, regardless of the error heuristic. The
+            # heuristic does substring matching ("error", "cannot", ...) that
+            # misclassifies legitimate source text, so it must not gate what
+            # the judge sees.
+            if event.tool_result is not None:
+                tool_label = (event.tool_use_id or "tool")
+                result_text = (
+                    event.tool_result
+                    if isinstance(event.tool_result, str)
+                    else json.dumps(event.tool_result, default=str)
+                )
+                accumulated_context.append(f"[{tool_label}] {result_text}")
+
         # Capture metrics from MetadataEvent
         if isinstance(event, MetadataEvent) and event.data:
             accumulated_metrics = event.data
-        
-        # Store guardrail violations asynchronously (fire-and-forget)
-        # Requirements 5.1, 5.4: Store violation without blocking response
+
+        # Store guardrail violations asynchronously (fire-and-forget) so
+        # violation capture never blocks the streamed response.
         if isinstance(event, GuardrailEvent) and event.action == "GUARDRAIL_INTERVENED":
             asyncio.create_task(
                 _store_guardrail_violation(event, session_id, user_id)
             )
-        
+
         yield event.to_sse_format()
 
     finally:
+        # Always cancel the producer task to avoid resource leaks if the client
+        # disconnects before the stream finishes.
         producer_task.cancel()
         try:
             await producer_task
@@ -298,21 +298,97 @@ async def _stream_chat_response(
 
     # Run evaluations asynchronously after stream completes (fire-and-forget).
     # Evaluation failures are handled internally and never impact the response.
+    # The wrapper first pulls recent conversation history from memory so judges
+    # can interpret follow-up turns (e.g. "yes") in context.
     full_output = "".join(accumulated_output)
     if full_output.strip():
         asyncio.create_task(
-            run_evaluations(
-                user_input=prompt,
-                agent_output=full_output,
+            _evaluate_turn_with_history(
+                prompt=prompt,
+                full_output=full_output,
                 session_id=session_id,
                 user_id=user_id,
                 model_id=model_id,
-                tool_usage=tool_usage_counts or None,
+                tool_usage_counts=tool_usage_counts or None,
                 input_tokens=accumulated_metrics.get("inputTokens", 0) or 0,
                 output_tokens=accumulated_metrics.get("outputTokens", 0) or 0,
-                context="\n\n".join(accumulated_context) if accumulated_context else None,
+                context_items=list(accumulated_context) if accumulated_context else None,
             )
         )
+
+
+async def _fetch_conversation_history(
+    session_id: str,
+    user_id: str,
+    exclude_texts: set[str],
+    max_messages: int = 10,
+) -> Optional[str]:
+    """Fetch recent conversation history from AgentCore Memory for eval context.
+
+    Returns a plain-text transcript of up to `max_messages` recent messages
+    (chronological), excluding any whose text matches the current turn so the
+    judge is not handed the answer it is supposed to assess. Returns None when
+    memory is unconfigured/empty or on any error (evaluation still runs without
+    history).
+    """
+    try:
+        from app.agentcore.memory import MemoryClient
+
+        mem = MemoryClient()
+        events = await mem.get_events(
+            session_id=session_id,
+            user_id=user_id,
+            max_results=max_messages * 2 + 4,
+        )
+        if not events:
+            return None
+
+        events = sorted(events, key=lambda e: e.timestamp)
+        lines = []
+        for ev in events:
+            text = (ev.content or "").strip()
+            if not text or text in exclude_texts:
+                continue
+            role = "User" if (ev.role or "").lower() == "user" else "Assistant"
+            lines.append(f"{role}: {text}")
+
+        if not lines:
+            return None
+        return "\n".join(lines[-max_messages:])
+    except Exception as e:
+        logger.warning("Failed to fetch conversation history for evaluation: %s", e)
+        return None
+
+
+async def _evaluate_turn_with_history(
+    prompt: str,
+    full_output: str,
+    session_id: str,
+    user_id: str,
+    model_id: str,
+    tool_usage_counts: Optional[Dict[str, Dict[str, int]]],
+    input_tokens: int,
+    output_tokens: int,
+    context_items: Optional[list[str]],
+) -> None:
+    """Fetch conversation history, then run evaluations (fire-and-forget)."""
+    history = await _fetch_conversation_history(
+        session_id=session_id,
+        user_id=user_id,
+        exclude_texts={prompt.strip(), full_output.strip()},
+    )
+    await run_evaluations(
+        user_input=prompt,
+        agent_output=full_output,
+        session_id=session_id,
+        user_id=user_id,
+        model_id=model_id,
+        tool_usage=tool_usage_counts,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        context_items=context_items,
+        conversation_history=history,
+    )
 
 
 async def _store_usage_record(

--- a/chatapp/app/routes/memory.py
+++ b/chatapp/app/routes/memory.py
@@ -12,7 +12,7 @@ from fastapi.responses import JSONResponse
 
 from app.auth.cognito import extract_user_id, TokenValidationError
 from app.auth.middleware import SESSION_COOKIE_NAME
-from app.agentcore.memory import MemoryClient, MemoryEvent, SemanticFact
+from app.agentcore.memory import MemoryClient, MemoryEvent, SemanticFact, EpisodicMemory
 
 
 router = APIRouter(prefix="/api/memory", tags=["memory"])
@@ -164,6 +164,54 @@ async def get_semantic_memory(
             "sessionId": session_id,
             "type": memory_type,
             "count": len(item_list),
+        }
+    )
+
+
+@router.get("/episodic")
+async def get_episodic_memory(
+    request: Request,
+    session_id: str = Query(..., description="Session ID for the conversation"),
+):
+    """Get episodic memory (structured interaction episodes) for a session.
+
+    Fetches episodic memory records from AgentCore Memory for the specified
+    session. Returns episodes with content and timestamp. Returns an empty
+    list (never errors) when no episodic strategy/records exist.
+
+    Args:
+        request: Incoming request with session cookie
+        session_id: Session ID for the conversation
+
+    Returns:
+        JSON response with episodes array
+    """
+    user_id = _get_user_id_from_session(request)
+
+    if not session_id or not session_id.strip():
+        raise HTTPException(status_code=400, detail="session_id is required")
+
+    client = MemoryClient()
+    episodes: List[EpisodicMemory] = await client.get_episodic(
+        session_id=session_id,
+        user_id=user_id,
+    )
+
+    episode_list = [
+        {
+            "id": ep.episode_id,
+            "content": ep.content,
+            "createdAt": ep.timestamp,
+        }
+        for ep in episodes
+    ]
+
+    return JSONResponse(
+        content={
+            "episodes": episode_list,
+            "items": episode_list,  # Generic key for frontend compatibility
+            "sessionId": session_id,
+            "count": len(episode_list),
         }
     )
 

--- a/chatapp/app/static/js/chat.js
+++ b/chatapp/app/static/js/chat.js
@@ -106,50 +106,26 @@ loadMemoryCacheFromStorage();
  * 
  * Requirements: 10.3
  */
-const AVAILABLE_MODELS = [
-    {
-        id: "global.anthropic.claude-opus-4-6-v1",
-        name: "Claude Opus 4.6",
-        description: "IN [$5.00] - OUT [$25.00]"
-    },
-    {
-        id: "global.anthropic.claude-sonnet-4-6",
-        name: "Claude Sonnet 4.6",
-        description: "IN [$3.00] - OUT [$15.00]"
-    },
-    {
-        id: "global.anthropic.claude-opus-4-5-20251101-v1:0",
-        name: "Claude Opus 4.5",
-        description: "IN [$5.00] - OUT [$25.00]"
-    },
-    {
-        id: "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        name: "Claude Sonnet 4.5",
-        description: "IN [$3.00] - OUT [$15.00]"
-    },
-    {
-        id: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-        name: "Claude Haiku 4.5",
-        description: "IN [$1.00] - OUT [$5.00]"
-    },
-    {
-        id: "us.amazon.nova-pro-v1:0",
-        name: "Nova Pro",
-        description: "IN [$0.80] - OUT [$3.20]"
-    },
-    {
-        id: "global.amazon.nova-2-lite-v1:0",
-        name: "Nova 2 Lite",
-        description: "IN [$0.30] - OUT [$2.50]"
-    }
-];
+// Model data is NOT hardcoded here. It comes from the single source of truth
+// at app/static/models.json, injected by base.html as window.__MODEL_CATALOG__
+// and read by Python via app/helpers/model_catalog.py. To add/remove/reprice a
+// model, edit models.json. Pricing is USD per 1M tokens.
+const _MODEL_CATALOG = (typeof window !== 'undefined' && window.__MODEL_CATALOG__) || { default_model_id: '', models: [] };
+
+const AVAILABLE_MODELS = (_MODEL_CATALOG.models || []).map(function (m) {
+    return {
+        id: m.id,
+        name: m.name,
+        description: "IN [$" + Number(m.input).toFixed(2) + "] - OUT [$" + Number(m.output).toFixed(2) + "]"
+    };
+});
 
 /**
  * Default model ID when no selection is stored.
  * 
  * Requirements: 10.8
  */
-const DEFAULT_MODEL_ID = "global.amazon.nova-2-lite-v1:0";
+const DEFAULT_MODEL_ID = _MODEL_CATALOG.default_model_id || "global.amazon.nova-2-lite-v1:0";
 
 /**
  * Get the currently selected model from localStorage.
@@ -964,6 +940,21 @@ function handleSSEEvent(event, msgId, currentContent) {
             // Filter out thinking tags (Requirement 2.6 - streaming indicator)
             let content = event.content || '';
             content = filterThinkingTags(content);
+            // Inject a paragraph break when assistant narration resumes after a
+            // tool ran, so tool output and following text don't run together.
+            // (Replaces the old server-side break injection in chat.py.)
+            // Only break when the pre-tool narration ended a sentence — the
+            // model often emits a word or two ("Here's") and then calls a tool
+            // mid-sentence, and we must not split that ("Here's" + break +
+            // "the current weather"). Mirrors the original server-side guard.
+            if (content.trim() && msgElement.dataset.afterTool === '1') {
+                msgElement.dataset.afterTool = '0';
+                var prevTrimmed = currentContent.replace(/\s+$/, '');
+                var lastChar = prevTrimmed.slice(-1);
+                if (prevTrimmed && (lastChar === '.' || lastChar === '!' || lastChar === '?')) {
+                    currentContent += '\n\n';
+                }
+            }
             currentContent += content;
             
             // Render markdown (Requirement 2.3 - render message content incrementally)
@@ -1059,6 +1050,8 @@ function handleSSEEvent(event, msgId, currentContent) {
             `;
             toolsContainer.insertAdjacentHTML('beforeend', toolUseHtml);
             updateToolsVisibility(toolsContainer);
+            // Mark that a tool ran so the next narration chunk gets a paragraph break
+            msgElement.dataset.afterTool = '1';
             scrollToBottom();
             break;
             

--- a/chatapp/app/static/models.json
+++ b/chatapp/app/static/models.json
@@ -1,0 +1,12 @@
+{
+  "default_model_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "models": [
+    { "id": "global.anthropic.claude-opus-4-8",              "name": "Claude Opus 4.8",   "input": 5.00, "output": 25.00 },
+    { "id": "global.anthropic.claude-opus-4-7",              "name": "Claude Opus 4.7",   "input": 5.00, "output": 25.00 },
+    { "id": "global.anthropic.claude-sonnet-4-6",               "name": "Claude Sonnet 4.6", "input": 3.00, "output": 15.00 },
+    { "id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0", "name": "Claude Sonnet 4.5", "input": 3.00, "output": 15.00 },
+    { "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",  "name": "Claude Haiku 4.5",  "input": 1.00, "output": 5.00 },
+    { "id": "us.amazon.nova-pro-v1:0",                          "name": "Nova Pro",          "input": 0.80, "output": 3.20 },
+    { "id": "global.amazon.nova-2-lite-v1:0",                   "name": "Nova 2 Lite",       "input": 0.30, "output": 2.50 }
+  ]
+}

--- a/chatapp/app/templates/admin/evaluation_session.html
+++ b/chatapp/app/templates/admin/evaluation_session.html
@@ -89,10 +89,6 @@
                                 {% else %}
                                 <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-red-50 text-red-700">FAIL</span>
                                 {% endif %}
-                                <span class="text-xs font-mono text-gray-500">{{ "%.2f"|format(ev.score) }}</span>
-                                {% if ev.label %}
-                                <span class="text-xs text-gray-400">{{ ev.label }}</span>
-                                {% endif %}
                             </div>
                         </div>
                         {% if ev.reason %}

--- a/chatapp/app/templates/base.html
+++ b/chatapp/app/templates/base.html
@@ -44,6 +44,12 @@
     
     <!-- DOMPurify for XSS protection when rendering markdown -->
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+
+    <!-- Model catalog: single source of truth (app/static/models.json),
+         injected so the front-end and Python read the very same data. -->
+    <script>
+        window.__MODEL_CATALOG__ = {{ (model_catalog if model_catalog else {"default_model_id": "", "models": []}) | tojson }};
+    </script>
     
     <!-- Custom styles -->
     <style>

--- a/chatapp/app/templates/components/sidebar.html
+++ b/chatapp/app/templates/components/sidebar.html
@@ -32,6 +32,7 @@
         <button id="tab-facts" onclick="switchMemoryTab('facts')" class="sidebar-tab flex-1 px-3 py-2 text-sm font-medium border-b-2 border-transparent transition-colors duration-200" style="color: var(--sidebar-text-muted);">Facts</button>
         <button id="tab-summaries" onclick="switchMemoryTab('summaries')" class="sidebar-tab flex-1 px-3 py-2 text-sm font-medium border-b-2 border-transparent transition-colors duration-200" style="color: var(--sidebar-text-muted);">Summaries</button>
         <button id="tab-preferences" onclick="switchMemoryTab('preferences')" class="sidebar-tab flex-1 px-3 py-2 text-sm font-medium border-b-2 border-transparent transition-colors duration-200" style="color: var(--sidebar-text-muted);">Prefs</button>
+        <button id="tab-episodes" onclick="switchMemoryTab('episodes')" class="sidebar-tab flex-1 px-3 py-2 text-sm font-medium border-b-2 border-transparent transition-colors duration-200" style="color: var(--sidebar-text-muted);">Episodes</button>
     </div>
     
     <div class="flex-1 overflow-y-auto p-4 transition-colors duration-200" style="background: var(--sidebar-bg);">
@@ -53,6 +54,11 @@
         <div id="memory-tab-preferences" class="memory-tab-content hidden">
             <div id="preferences-memory-content">
                 <p class="text-sm text-center py-4" style="color: var(--sidebar-text-muted);">Loading preferences...</p>
+            </div>
+        </div>
+        <div id="memory-tab-episodes" class="memory-tab-content hidden">
+            <div id="episodes-memory-content">
+                <p class="text-sm text-center py-4" style="color: var(--sidebar-text-muted);">Loading episodes...</p>
             </div>
         </div>
     </div>
@@ -99,7 +105,7 @@ function applySidebarTheme(theme) {
 }
 
 function updateTabStyling(activeTab) {
-    ['events', 'facts', 'summaries', 'preferences'].forEach(t => {
+    ['events', 'facts', 'summaries', 'preferences', 'episodes'].forEach(t => {
         const btn = document.getElementById('tab-' + t);
         if (!btn) return;
         if (t === activeTab) {
@@ -117,7 +123,7 @@ function updateTabStyling(activeTab) {
 }
 
 function switchMemoryTab(tab) {
-    ['events', 'facts', 'summaries', 'preferences'].forEach(t => {
+    ['events', 'facts', 'summaries', 'preferences', 'episodes'].forEach(t => {
         const content = document.getElementById('memory-tab-' + t);
         if (content) {
             if (t === tab) content.classList.remove('hidden');
@@ -127,6 +133,7 @@ function switchMemoryTab(tab) {
     currentMemoryTab = tab;
     updateTabStyling(tab);
     if (tab === 'events') loadEventMemory();
+    else if (tab === 'episodes') loadEpisodicMemory();
     else loadSemanticMemoryByType(tab);
 }
 
@@ -331,5 +338,97 @@ function addMessageToEventCache(role, content) {
     if (container && currentMemoryTab === 'events') {
         renderEventMemoryItems(memoryCache.events.messages, container);
     }
+}
+</script>
+
+<script>
+async function loadEpisodicMemory(forceRefresh) {
+    var container = document.getElementById('episodes-memory-content');
+    if (!container) return;
+    var currentSessionId = typeof getSessionId === 'function' ? getSessionId() : sessionId;
+    if (!forceRefresh && typeof memoryCache !== 'undefined' && memoryCache.episodes && memoryCache.sessionId === currentSessionId) {
+        renderEpisodicMemoryItems(memoryCache.episodes, container);
+        return;
+    }
+    container.innerHTML = '<div class="flex items-center justify-center py-4"><svg class="w-5 h-5 animate-spin mr-2" style="color: var(--sidebar-badge-text);" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg><span class="text-sm" style="color: var(--sidebar-text-muted);">Loading episodes...</span></div>';
+    try {
+        var sid = typeof getSessionId === 'function' ? getSessionId() : sessionId;
+        var response = await fetch('/api/memory/episodic?session_id=' + sid);
+        if (response.status === 401) { window.location.href = '/auth/login?error=session_expired'; return; }
+        if (!response.ok) throw new Error('Failed to load episodes');
+        var data = await response.json();
+        var items = data.episodes || data.items || [];
+        if (typeof memoryCache !== 'undefined') { memoryCache.episodes = items; memoryCache.sessionId = sid; if (typeof saveMemoryCacheToStorage === 'function') saveMemoryCacheToStorage(); }
+        renderEpisodicMemoryItems(items, container);
+    } catch (error) {
+        console.error('Failed to load episodes:', error);
+        container.innerHTML = '<div class="text-center py-4"><svg class="w-8 h-8 text-red-400 mx-auto mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg><p class="text-red-500 text-sm">Failed to load episodes</p><button onclick="loadEpisodicMemory(true)" class="mt-2 text-xs hover:opacity-80 underline" style="color: var(--sidebar-badge-text);">Try again</button></div>';
+    }
+}
+
+function renderEpisodicMemoryItems(items, container) {
+    if (!items || items.length === 0) {
+        container.innerHTML = '<div class="text-center py-8"><svg class="w-12 h-12 mx-auto mb-3" style="color: var(--sidebar-empty-icon);" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg><p class="text-sm" style="color: var(--sidebar-text-muted);">No episodes recorded yet</p><p class="text-xs mt-1" style="color: var(--sidebar-text-muted); opacity: 0.7;">Structured interaction episodes will appear here</p></div>';
+        return;
+    }
+    container.innerHTML = items.map(function(item, idx) {
+        var ts = item.createdAt || item.timestamp;
+        var content = item.content || '';
+        var bodyHtml = formatEpisodeBody(content);
+        return '<div class="p-3 rounded-lg mb-2" style="background: var(--sidebar-card-bg); border: 1px solid var(--sidebar-card-border);"><div class="flex items-center gap-2 mb-2"><span class="text-xs font-medium px-2 py-0.5 rounded" style="background: var(--sidebar-badge-bg); color: var(--sidebar-badge-text);">#' + (idx + 1) + '</span><span class="text-lg">🧩</span><span class="text-xs font-medium" style="color: var(--sidebar-text);">Episode</span><span class="text-xs ml-auto" style="color: var(--sidebar-text-muted);">' + formatFullDate(ts) + '</span></div>' + bodyHtml + '</div>';
+    }).join('');
+}
+
+// Render an episode's content. Episodes are stored as a structured JSON object
+// (situation/intent/assessment/justification/reflection); format those as
+// labeled sections. Fall back to markdown/plain text for non-JSON content.
+function formatEpisodeBody(content) {
+    var obj = null;
+    if (typeof content === 'string' && content.trim().charAt(0) === '{') {
+        try { obj = JSON.parse(content); } catch (e) { obj = null; }
+    } else if (content && typeof content === 'object') {
+        obj = content;
+    }
+    if (!obj || typeof obj !== 'object') {
+        var text = (typeof marked !== 'undefined') ? marked.parse(content || '') : escapeHtml(content || '');
+        return '<div class="text-sm markdown-content memory-markdown" style="color: var(--sidebar-text);">' + text + '</div>';
+    }
+    var FIELDS = [
+        ['situation', 'Situation'],
+        ['intent', 'Intent'],
+        ['assessment', 'Assessment'],
+        ['justification', 'Justification'],
+        ['reflection', 'Reflection'],
+    ];
+    var seen = {};
+    var html = '';
+    function sectionHtml(label, value) {
+        if (value === null || value === undefined) return '';
+        var v = String(value).trim();
+        if (!v) return '';
+        if (label === 'Assessment') {
+            var low = v.toLowerCase();
+            var ok = (low === 'yes' || low === 'true' || low === 'achieved' || low === 'success');
+            var bg = ok ? 'rgba(34,197,94,0.18)' : 'rgba(245,158,11,0.18)';
+            var fg = ok ? '#4ade80' : '#fbbf24';
+            return '<div class="mb-2"><span class="text-xs font-semibold" style="color: var(--sidebar-text-muted);">' + label + ':</span> ' +
+                   '<span class="text-xs font-medium px-2 py-0.5 rounded ml-1" style="background:' + bg + '; color:' + fg + ';">' + escapeHtml(v) + '</span></div>';
+        }
+        return '<div class="mb-2"><span class="text-xs font-semibold" style="color: var(--sidebar-text-muted);">' + label + ':</span>' +
+               '<p class="text-sm mt-0.5" style="color: var(--sidebar-text);">' + escapeHtml(v) + '</p></div>';
+    }
+    FIELDS.forEach(function(f) {
+        seen[f[0]] = true;
+        html += sectionHtml(f[1], obj[f[0]]);
+    });
+    Object.keys(obj).forEach(function(k) {
+        if (seen[k]) return;
+        var label = k.charAt(0).toUpperCase() + k.slice(1).replace(/_/g, ' ');
+        html += sectionHtml(label, obj[k]);
+    });
+    if (!html) {
+        html = '<pre class="text-xs whitespace-pre-wrap break-words" style="color: var(--sidebar-text);">' + escapeHtml(JSON.stringify(obj, null, 2)) + '</pre>';
+    }
+    return html;
 }
 </script>

--- a/chatapp/app/templates_config.py
+++ b/chatapp/app/templates_config.py
@@ -29,7 +29,12 @@ async def init_template_globals():
     into the Jinja2 environment globals.
     """
     from app.helpers import get_app_settings
-    
+    from app.helpers.model_catalog import load_catalog
+
+    # Single source of truth for model ids/names/pricing, shared with the
+    # front-end via window.__MODEL_CATALOG__ (see base.html).
+    templates.env.globals["model_catalog"] = load_catalog()
+
     try:
         # Load settings asynchronously at startup
         settings = await get_app_settings()


### PR DESCRIPTION
## Summary
Batches several independent improvements to the chatapp, agent, and CDK infra. Each concern is its own commit for easy review.

## Changes (by commit)
1. **chore(cdk):** bump `aws-cdk` to address dependency vulnerabilities.
2. **fix(cdk):** `destroy-all.sh` now explicitly deletes the ECS Express Gateway service and bulk-deletes app-owned CloudWatch log groups by prefix, since leftovers block future redeploys.
3. **feat(memory):** add an AgentCore **episodic** memory strategy (Bedrock stack) and surface it in the chatapp — `get_episodic` client method, `/api/memory/episodic` route, and an Episodes tab in the memory sidebar.
4. **feat(models):** centralize model ids/names/pricing in `app/static/models.json` as a single source of truth, shared by the backend (`cost_calculator`, template globals) and the front-end (`window.__MODEL_CATALOG__` in `base.html`, consumed by `chat.js`).
5. **feat(evals):** evaluation quality improvements:
   - Capability manifest so judges don't flag truthful tool claims as hallucinations (grounds `answer_quality` and `faithfulness`).
   - Pass conversation history into judges so follow-ups like "yes" are scored in context.
   - Budget faithfulness source context fairly across tool results so a late/small result isn't truncated away.
   - Capture all tool-result content blocks (text and json) in the agent.
   - Make `tool_selection` binary pass/fail; drop the keyword "expected tools" heuristic; hide raw scores/labels in the session view.
6. **fix(auth):** read admin status from the verified `cognito:groups` token claim instead of a per-request `admin_list_groups_for_user` call, and apply admin resolution + admin-route authorization on the token-refresh path too. Fixes the admin menu disappearing (and admin routes being unguarded) on the first request after the access token expires.

## Notes for reviewers
- Two commits carry a little adjacent work: `chat.py` (evals) also includes pre-existing streaming-keepalive changes; `chat.js` (models) also includes a small client-side render tweak that pairs with a server-side removal in `chat.py`.
- Admin status is now token-derived, so Admin group membership changes take effect on the next login/token refresh rather than instantly. This assumes tokens carry `cognito:groups` (Cognito default for users in any group).

## Testing
- Python files compile; evaluator and context-budgeting logic spot-checked locally.
- Live LLM-judge behavior and the auth refresh flow need a deployed environment to fully verify.
