### PR TITLE
fix(cdk): inject app settings and runtime usage table names into ECS/Lambda

### DIFF
--- a/cdk/lib/chatapp-stack.ts
+++ b/cdk/lib/chatapp-stack.ts
@@ -594,6 +594,14 @@ def handler(event, context):
             name: 'EVALUATIONS_TABLE_NAME',
             valueFrom: `${secretArn}:evaluations_table_name::`,
           },
+          {
+            name: 'APP_SETTINGS_TABLE_NAME',
+            valueFrom: `${secretArn}:app_settings_table_name::`,
+          },
+          {
+            name: 'RUNTIME_USAGE_TABLE_NAME',
+            valueFrom: `${secretArn}:runtime_usage_table_name::`,
+          },
         ],
         
         // Environment variables (non-secret)
@@ -979,6 +987,8 @@ def handler(event, context):
       'GUARDRAIL_VERSION': 'guardrail_version',
       'KB_ID': 'kb_id',
       'EVALUATIONS_TABLE_NAME': 'evaluations_table_name',
+      'APP_SETTINGS_TABLE_NAME': 'app_settings_table_name',
+      'RUNTIME_USAGE_TABLE_NAME': 'runtime_usage_table_name',
     };
     
     // Add each secret as an environment variable


### PR DESCRIPTION
## Summary
App color/branding settings saved fine locally but silently failed on deployed (ECS/Lambda) environments. Root cause: the ChatApp container resolves its DynamoDB table names from env vars and falls back to non-existent `agentcore-*` defaults when those vars are unset.

The ECS Express Gateway `secrets` array and the Lambda `secretFields` map both omitted two table-name env vars while injecting all others:
- `APP_SETTINGS_TABLE_NAME` (title, logos, theme colors)
- `RUNTIME_USAGE_TABLE_NAME` (admin runtime/compute cost tracking)

As a result, settings reads/writes and runtime usage queries targeted a table that doesn't exist. Writes were swallowed by error handling (looked like a successful save), and reads returned empty so the UI reverted to defaults.

## Fix
Inject both env vars from the existing Foundation Secrets Manager secret in both deployment paths. No IAM or secret changes required:
- Both values already exist in the secret (`app_settings_table_name`, `runtime_usage_table_name`)
- The task role's `DynamoDBAccess` statement already covers both real table ARNs

## Audit
All 7 table-name env vars the ChatApp reads are now injected in both ECS and Lambda. The other five (USAGE, FEEDBACK, GUARDRAIL, PROMPT_TEMPLATES, EVALUATIONS) were already present.

## Testing
- `npx tsc --noEmit` passes
- Deployed and verified app settings (colors) now persist on ECS
