### PR TITLE
feat: Knowledge Base Explorer with seeded doc and auto-ingestion

### DIFF
--- a/cdk/assets/kb-seed/about-agentcore-chat-app.md
+++ b/cdk/assets/kb-seed/about-agentcore-chat-app.md
@@ -1,0 +1,107 @@
+# About the AgentCore Chat Application
+
+> **Document class:** REFERENCE · **Topic:** Application overview, architecture, and features
+>
+> This article describes the AgentCore Chat Application starter kit. It is seeded into the
+> Knowledge Base by default so the agent has something to retrieve and the Knowledge Base
+> Explorer has a document to display out of the box.
+
+## 1. What this application is
+
+The AgentCore Chat Application is a full-stack conversational AI starter kit. It pairs a
+Python agent (built on the Strands Agents framework and deployed to Amazon Bedrock
+AgentCore Runtime) with a FastAPI web front end. The kit is designed for proof-of-concept
+development: it ships with authentication, conversation memory, usage analytics, cost
+projection, and a Knowledge Base out of the box.
+
+Core capabilities:
+
+- Conversational agent with persistent memory using Amazon Bedrock AgentCore.
+- Real-time, token-by-token streaming of responses over Server-Sent Events (SSE).
+- Secure sign-in through Amazon Cognito using the direct InitiateAuth API (no hosted UI).
+- A modern chat interface with markdown rendering and syntax highlighting.
+- Session management with conversation history.
+- A memory viewer showing events, facts, summaries, and preferences.
+- An admin dashboard with usage analytics and cost tracking (token plus runtime cost).
+- User feedback capture (thumbs up/down with comments).
+- Guardrails analytics with violation tracking.
+- Prompt templates for quick access to pre-defined prompts.
+- Knowledge Base integration for semantic search over curated documents.
+- A Knowledge Base Explorer for browsing, searching, and uploading source documents.
+
+## 2. Architecture
+
+The system is composed of four parts:
+
+1. **Agent backend** — a Python agent using the Strands Agents framework, deployed to the
+   Amazon Bedrock AgentCore Runtime. It exposes tools for web search, URL fetching,
+   weather lookup, and Knowledge Base search.
+2. **Chat application** — a FastAPI service that renders Jinja2 templates, proxies chat
+   requests to the AgentCore Runtime, and serves the admin dashboard. Styling uses
+   Tailwind CSS via CDN; streaming uses vanilla JavaScript.
+3. **Memory and storage** — AgentCore Memory provides event and semantic memory for
+   conversation persistence. DynamoDB stores usage records, feedback, guardrail
+   violations, prompt templates, application settings, and runtime usage.
+4. **Knowledge Base** — an Amazon Bedrock Knowledge Base backed by S3 Vectors. Source
+   documents live in an S3 bucket under the `documents/` prefix and are embedded with the
+   Amazon Titan Text Embeddings V2 model.
+
+## 3. How the Knowledge Base works
+
+Source documents are stored in a dedicated S3 bucket under the `documents/` prefix. Amazon
+Bedrock ingests those documents, splits them into chunks, embeds each chunk with Titan
+Text Embeddings V2, and stores the vectors in an S3 Vectors index. At query time the agent
+calls the `Retrieve` API, which performs a vector similarity search and returns the most
+relevant passages.
+
+When you add or change documents, Bedrock must run an *ingestion job* to pick up the
+changes. The Knowledge Base Explorer triggers an ingestion job automatically after an
+upload, so newly uploaded files become retrievable within a few minutes.
+
+## 4. The Knowledge Base Explorer
+
+The Knowledge Base Explorer is an admin page that lets you:
+
+- **Browse** every source document in the Knowledge Base as a flat list.
+- **Search** the Knowledge Base with the same semantic retrieval the agent uses, so you can
+  validate what the agent will see for a given question.
+- **Read** a document's contents directly in the browser when the file is text-based
+  (for example Markdown, plain text, JSON, CSV, or YAML).
+- **Upload** new documents into the Knowledge Base. Uploaded files are written to the
+  `documents/uploads/` prefix and an ingestion job is started automatically.
+
+Use the Explorer to confirm the data the agent relies on and to seed new domain knowledge
+for testing.
+
+## 5. Deployment
+
+The application is deployed with the AWS CDK (TypeScript). Four stacks are provisioned:
+
+- **Foundation** — Cognito, DynamoDB tables, IAM roles, and Secrets Manager.
+- **Bedrock** — the Guardrail, the Knowledge Base (with its S3 Vectors index and source
+  bucket), and AgentCore Memory.
+- **Agent** — the ECR repository, CodeBuild project, AgentCore Runtime, and observability.
+- **ChatApp** — the web front end, hosted on ECS Express Mode or on CloudFront with a
+  Lambda Web Adapter.
+
+The default foundation model is Anthropic Claude Sonnet. The embedding model for the
+Knowledge Base is Amazon Titan Text Embeddings V2 (1024 dimensions, cosine distance).
+
+## 6. Frequently asked questions
+
+**How do I add knowledge for the agent to use?**
+Upload a document through the Knowledge Base Explorer, or copy files into the `documents/`
+prefix of the Knowledge Base source bucket and start an ingestion job. The Explorer starts
+the job for you on upload.
+
+**Why doesn't the agent know about a document I just added?**
+Bedrock needs to run an ingestion job before new content is retrievable. Ingestion takes a
+few minutes. If you added files outside the Explorer, start the ingestion job manually.
+
+**What file types can the Explorer preview?**
+Text-based files such as Markdown, plain text, JSON, CSV, YAML, HTML, and XML are rendered
+inline. Binary formats such as PDF are listed but not previewed in the browser.
+
+**Where are conversations stored?**
+Short-term conversation context and long-term memory (summaries, facts, and preferences)
+are stored in AgentCore Memory. Usage and analytics records are stored in DynamoDB.

--- a/cdk/lib/bedrock-stack.ts
+++ b/cdk/lib/bedrock-stack.ts
@@ -15,6 +15,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as bedrock from 'aws-cdk-lib/aws-bedrock';
@@ -22,8 +23,9 @@ import * as bedrockagentcore from 'aws-cdk-lib/aws-bedrockagentcore';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
+import * as path from 'path';
 import { config, exportNames } from './config';
-import { applyCommonSuppressions } from './nag-suppressions';
+import { applyCommonSuppressions, applyBucketDeploymentSuppressions, applyCustomResourceSuppressions } from './nag-suppressions';
 
 export class BedrockStack extends cdk.Stack {
   // Guardrail resources
@@ -320,6 +322,62 @@ export class BedrockStack extends cdk.Stack {
     // Ensure data source is created after KB
     this.dataSource.addDependency(this.knowledgeBase);
 
+    // ========================================================================
+    // SEED DOCUMENT + DEFAULT INGESTION
+    // ========================================================================
+    // Seed a default Knowledge Base article (about this application) into the
+    // source bucket under the documents/ prefix, then start an ingestion job so
+    // the agent has retrievable content and the KB Explorer has a document to
+    // display out of the box.
+
+    const seedDeployment = new s3deploy.BucketDeployment(this, 'KbSeedDeployment', {
+      sources: [s3deploy.Source.asset(path.join(__dirname, '../assets/kb-seed'))],
+      destinationBucket: this.sourceBucket,
+      destinationKeyPrefix: 'documents/',
+      prune: false, // never delete agent/admin-uploaded documents in this prefix
+      retainOnDelete: false,
+      memoryLimit: 256,
+    });
+
+    // Start an ingestion job on deploy so the seeded (and any pre-existing)
+    // documents are embedded into the vector index automatically. The timestamp
+    // forces the job to re-run on each deploy, keeping the index in sync.
+    const ingestionTimestamp = new Date().toISOString();
+    const startIngestion = new cr.AwsCustomResource(this, 'StartKbIngestion', {
+      onCreate: {
+        service: 'bedrock-agent',
+        action: 'startIngestionJob',
+        parameters: {
+          knowledgeBaseId: this.knowledgeBase.attrKnowledgeBaseId,
+          dataSourceId: this.dataSource.attrDataSourceId,
+          description: 'Initial ingestion of seeded Knowledge Base documents',
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(`${config.appName}-kb-seed-ingestion`),
+      },
+      onUpdate: {
+        service: 'bedrock-agent',
+        action: 'startIngestionJob',
+        parameters: {
+          knowledgeBaseId: this.knowledgeBase.attrKnowledgeBaseId,
+          dataSourceId: this.dataSource.attrDataSourceId,
+          description: 'Re-ingestion of seeded Knowledge Base documents',
+          clientToken: ingestionTimestamp.replace(/[^a-zA-Z0-9]/g, '').substring(0, 32),
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(`${config.appName}-kb-seed-ingestion`),
+      },
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['bedrock:StartIngestionJob'],
+          resources: [this.knowledgeBase.attrKnowledgeBaseArn],
+        }),
+      ]),
+    });
+
+    // Ingestion must wait for the documents to land and the data source to exist.
+    startIngestion.node.addDependency(seedDeployment);
+    startIngestion.node.addDependency(this.dataSource);
+
 
     // ========================================================================
     // MEMORY SECTION
@@ -555,6 +613,8 @@ def handler(event, context):
     // ========================================================================
     
     applyCommonSuppressions(this);
+    applyBucketDeploymentSuppressions(this);
+    applyCustomResourceSuppressions(this);
 
     // Suppress S3 vectors custom resource wildcards
     NagSuppressions.addResourceSuppressionsByPath(

--- a/cdk/lib/chatapp-stack.ts
+++ b/cdk/lib/chatapp-stack.ts
@@ -618,6 +618,12 @@ def handler(event, context):
             name: 'LOG_LEVEL',
             value: 'INFO',
           },
+          {
+            // KB source bucket (deterministic name from Bedrock stack) so the
+            // Knowledge Base Explorer can list/read/upload source documents.
+            name: 'KB_SOURCE_BUCKET',
+            value: `${config.appName}-kb-${this.account}-${this.region}`,
+          },
         ],
       },
     });
@@ -960,6 +966,9 @@ def handler(event, context):
         'LOG_LEVEL': 'INFO',
         'AWS_LWA_INVOKE_MODE': 'response_stream',  // Enable SSE streaming
         'AWS_LWA_PORT': '8080',
+        // KB source bucket (deterministic name from Bedrock stack) so the
+        // Knowledge Base Explorer can list/read/upload source documents.
+        'KB_SOURCE_BUCKET': `${config.appName}-kb-${this.account}-${this.region}`,
       },
     });
     

--- a/cdk/lib/foundation-stack.ts
+++ b/cdk/lib/foundation-stack.ts
@@ -642,6 +642,46 @@ export class FoundationStack extends cdk.Stack {
       })
     );
 
+    // Knowledge Base access for the Knowledge Base Explorer:
+    // - Retrieve: run the same semantic search the agent uses.
+    // - ListDataSources / StartIngestionJob / GetIngestionJob: trigger and
+    //   track ingestion after a document is uploaded through the Explorer.
+    this.taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'KnowledgeBaseExplorerAccess',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'bedrock:Retrieve',
+          'bedrock:ListDataSources',
+          'bedrock:StartIngestionJob',
+          'bedrock:GetIngestionJob',
+        ],
+        resources: [
+          `arn:aws:bedrock:${this.region}:${this.account}:knowledge-base/*`,
+        ],
+      })
+    );
+
+    // KB source bucket access for the Explorer: list documents, read text
+    // documents, and upload new ones under the documents/ prefix. The bucket
+    // name is deterministic (see Bedrock stack SourceBucket).
+    const kbSourceBucketArn = `arn:aws:s3:::${config.appName}-kb-${this.account}-${this.region}`;
+    this.taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'KnowledgeBaseSourceBucketAccess',
+        effect: iam.Effect.ALLOW,
+        actions: [
+          's3:ListBucket',
+          's3:GetObject',
+          's3:PutObject',
+        ],
+        resources: [
+          kbSourceBucketArn,
+          `${kbSourceBucketArn}/documents/*`,
+        ],
+      })
+    );
+
     // CloudWatch Logs permissions
     this.taskRole.addToPolicy(
       new iam.PolicyStatement({
@@ -961,6 +1001,16 @@ export class FoundationStack extends cdk.Stack {
           id: 'AwsSolutions-IAM5',
           reason: 'CloudWatch log group name includes dynamic service name. Scoped to app-specific log groups.',
           appliesTo: [`Resource::arn:aws:logs:${this.region}:${this.account}:log-group:/ecs/${config.appName}*`],
+        },
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'Knowledge Base Explorer needs Retrieve and ingestion actions. The KB ID is created in the Bedrock stack and not known here, so the resource is scoped to knowledge bases in this account/region.',
+          appliesTo: [`Resource::arn:aws:bedrock:${this.region}:${this.account}:knowledge-base/*`],
+        },
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'Knowledge Base Explorer reads/writes source documents under the documents/ prefix of the KB source bucket. Object keys are not known at synthesis time.',
+          appliesTo: [`Resource::arn:aws:s3:::${config.appName}-kb-${this.account}-${this.region}/documents/*`],
         },
         {
           id: 'AwsSolutions-IAM5',

--- a/chatapp/.env.example
+++ b/chatapp/.env.example
@@ -21,6 +21,12 @@ PROMPT_TEMPLATES_TABLE_NAME=agentcore-prompt-templates
 # App Settings Configuration
 APP_SETTINGS_TABLE_NAME=agentcore-app-settings
 
+# Knowledge Base Configuration (for the Knowledge Base Explorer at /admin/kb)
+# KB_ID is the Bedrock Knowledge Base ID; KB_SOURCE_BUCKET is the S3 bucket
+# holding source documents under the documents/ prefix.
+KB_ID=your-knowledge-base-id
+KB_SOURCE_BUCKET=htmx-chatapp-kb-123456789012-us-east-1
+
 # Guardrail Configuration (optional - for soft-launch guardrails)
 # Set GUARDRAIL_ID and GUARDRAIL_VERSION from setup-guardrail.sh output
 GUARDRAIL_ID=your-guardrail-id

--- a/chatapp/app/main.py
+++ b/chatapp/app/main.py
@@ -22,6 +22,7 @@ from app.routes.admin import router as admin_router
 from app.routes.feedback import router as feedback_router, admin_router as feedback_admin_router
 from app.routes.prompt_templates import router as templates_router, admin_router as templates_admin_router
 from app.routes.app_settings import api_router as settings_api_router, admin_router as settings_admin_router
+from app.routes.knowledge_base import api_router as kb_api_router, admin_router as kb_admin_router
 
 # Set up paths
 BASE_DIR = Path(__file__).resolve().parent
@@ -109,6 +110,8 @@ app.include_router(templates_router)
 app.include_router(templates_admin_router)
 app.include_router(settings_api_router)
 app.include_router(settings_admin_router)
+app.include_router(kb_api_router)
+app.include_router(kb_admin_router)
 
 # Add hot reload route if enabled
 if hot_reload:

--- a/chatapp/app/routes/knowledge_base.py
+++ b/chatapp/app/routes/knowledge_base.py
@@ -1,0 +1,100 @@
+"""Knowledge Base Explorer routes.
+
+A browser over the documents the agent's Bedrock Knowledge Base is built from:
+
+* **Documents** — a flat list of every source document (no scopes). Browse the
+  list, read text-based files inline, and upload new documents.
+* **Semantic search** — run the same retrieval the agent uses to validate what
+  it will see for a given question.
+
+The page (``/admin/kb``) is admin-gated by ``AuthMiddleware`` (ADMIN_PREFIXES).
+The JSON API (``/api/kb/*``) requires authentication; the upload endpoint
+additionally requires admin. The page renders a shell; documents and search
+results load lazily through the JSON API so a slow call never blocks the page.
+"""
+
+import logging
+
+from fastapi import APIRouter, Request, Query, UploadFile, File
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from app.templates_config import templates
+from app.storage import knowledge_base as kb
+
+logger = logging.getLogger(__name__)
+
+# Admin router for the page (admin-gated via middleware ADMIN_PREFIXES).
+admin_router = APIRouter(prefix="/admin", tags=["knowledge-base"])
+
+# API router for lazy data loading (JSON 401 handling via middleware).
+api_router = APIRouter(prefix="/api/kb", tags=["knowledge-base-api"])
+
+
+# ── Page ──────────────────────────────────────────────────────────────────────
+@admin_router.get("/kb", response_class=HTMLResponse)
+async def knowledge_base_page(request: Request):
+    """Render the Knowledge Base Explorer shell."""
+    user = getattr(request.state, "user", None)
+    user_email = user.email if user else None
+    is_admin = getattr(request.state, "is_admin", False)
+
+    from app.helpers import get_app_settings
+    app_settings = await get_app_settings()
+
+    return templates.TemplateResponse(
+        "admin/knowledge_base.html",
+        {
+            "request": request,
+            "user_email": user_email,
+            "is_admin": is_admin,
+            "kb_configured": kb.is_configured(),
+            "breadcrumbs": [
+                {"label": "Admin", "url": "/admin"},
+                {"label": "Knowledge Base"},
+            ],
+            "primary_action": {"type": "back_to_chat"},
+            **app_settings,
+        },
+    )
+
+
+# ── JSON API ────────────────────────────────────────────────────────────────────
+@api_router.get("/documents")
+async def api_documents() -> JSONResponse:
+    """List KB source documents (flat, no scope)."""
+    return JSONResponse(await kb.list_documents())
+
+
+@api_router.get("/document")
+async def api_document(key: str = Query(..., min_length=1)) -> JSONResponse:
+    """Read one KB source document's contents (when text-based)."""
+    return JSONResponse(await kb.get_document(key))
+
+
+@api_router.get("/search")
+async def api_search(q: str = Query("", alias="q")) -> JSONResponse:
+    """Semantic retrieval against the vector Knowledge Base."""
+    return JSONResponse(await kb.search(q))
+
+
+@api_router.post("/upload")
+async def api_upload(request: Request, file: UploadFile = File(...)) -> JSONResponse:
+    """Upload a new document into the Knowledge Base and start ingestion.
+
+    Admin-only: the JSON API prefix is not admin-gated by the middleware, so the
+    check is enforced here.
+    """
+    if not getattr(request.state, "is_admin", False):
+        return JSONResponse(
+            content={"error": "You must be an administrator to upload documents."},
+            status_code=403,
+        )
+
+    data = await file.read()
+    result = await kb.upload_document(
+        filename=file.filename or "upload",
+        data=data,
+        content_type=file.content_type or "",
+    )
+    status = 400 if result.get("error") else 200
+    return JSONResponse(content=result, status_code=status)

--- a/chatapp/app/static/js/knowledge_base.js
+++ b/chatapp/app/static/js/knowledge_base.js
@@ -1,0 +1,180 @@
+/* Knowledge Base Explorer — browse, search, read, and upload the documents the
+ * agent's Bedrock Knowledge Base is built from. Flat list (no scopes). Data
+ * loads lazily from /api/kb/* so a slow call never blocks the page. */
+(function () {
+  "use strict";
+
+  var state = { doc: null };
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+  function el(id) { return document.getElementById(id); }
+  // Single audited DOM-write point: callers pass static markup authored here or
+  // values escaped via esc(), keeping the XSS-safety invariant in one place.
+  function setHTML(node, html) {
+    if (!node) return;
+    node.innerHTML = html;
+  }
+  function esc(s) {
+    if (s === null || s === undefined) return "";
+    return String(s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+  function spinner(label) {
+    return '<div class="h-full flex flex-col items-center justify-center gap-3 p-10" style="color: var(--text-muted);">' +
+      '<div class="kb-spin"></div><p class="text-sm">' + esc(label || "Loading…") + "</p></div>";
+  }
+  function fmtBytes(n) {
+    if (!n && n !== 0) return "";
+    if (n < 1024) return n + " B";
+    if (n < 1048576) return (n / 1024).toFixed(1) + " KB";
+    return (n / 1048576).toFixed(1) + " MB";
+  }
+  function getJSON(url) {
+    return fetch(url, { credentials: "same-origin", headers: { "Accept": "application/json" } })
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); });
+  }
+  function docIcon() {
+    return '<svg class="w-4 h-4 shrink-0" style="color: var(--text-subtle);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/></svg>';
+  }
+
+  // ── Documents ───────────────────────────────────────────────────────────
+  function loadDocs() {
+    var list = el("kb-doc-list");
+    setHTML(list, spinner("Loading documents…"));
+    state.doc = null;
+    getJSON("/api/kb/documents").then(function (data) {
+      var docs = data.documents || [];
+      el("kb-doc-count").textContent = docs.length;
+      if (data.error && !docs.length) {
+        setHTML(list, '<div class="p-2"><div class="kb-banner kb-banner-warn">' + esc(data.error) + "</div></div>");
+        return;
+      }
+      if (!docs.length) {
+        setHTML(list, '<p class="text-xs p-3" style="color: var(--text-subtle);">No documents found. Upload a file to get started.</p>');
+        return;
+      }
+      setHTML(list, "");
+      docs.forEach(function (doc) {
+        var b = document.createElement("button");
+        b.className = "kb-item";
+        b.dataset.key = doc.key;
+        setHTML(b,
+          docIcon() +
+          '<span class="flex-1 min-w-0"><span class="block text-xs truncate" style="color: var(--text);">' + esc(doc.name) + "</span>" +
+          '<span class="block tg-mono text-[10px] truncate" style="color: var(--text-subtle);">' + esc(fmtBytes(doc.size)) +
+          (doc.readable ? "" : " · preview n/a") + "</span></span>");
+        b.onclick = function () { selectDoc(doc); };
+        list.appendChild(b);
+      });
+    }).catch(function (e) {
+      setHTML(list, '<div class="p-2"><div class="kb-banner kb-banner-warn">Failed to load documents: ' + esc(e.message) + "</div></div>");
+    });
+  }
+
+  function selectDoc(doc) {
+    state.doc = doc.key;
+    document.querySelectorAll("#kb-doc-list .kb-item").forEach(function (b) {
+      b.classList.toggle("is-active", b.dataset.key === doc.key);
+    });
+    el("kb-doc-title").textContent = doc.name;
+    el("kb-doc-sub").textContent = doc.key;
+    var body = el("kb-doc-body");
+    setHTML(body, spinner("Loading document…"));
+    getJSON("/api/kb/document?key=" + encodeURIComponent(doc.key)).then(function (data) {
+      if (data.error) {
+        setHTML(body, '<div class="kb-banner kb-banner-warn">' + esc(data.error) + "</div>");
+        return;
+      }
+      if (data.readable === false || data.notice) {
+        setHTML(body, '<div class="kb-rise"><div class="kb-banner kb-banner-warn">' +
+          esc(data.notice || "Preview is not available for this file type.") + "</div></div>");
+        return;
+      }
+      setHTML(body, '<div class="kb-rise kb-doc">' + esc(data.content) + "</div>");
+    }).catch(function (e) {
+      setHTML(body, '<div class="kb-banner kb-banner-warn">Could not read document: ' + esc(e.message) + "</div>");
+    });
+  }
+
+  // ── Semantic search ───────────────────────────────────────────────────────
+  window.kbSearch = function () {
+    var q = el("kb-search").value.trim();
+    var panel = el("kb-results");
+    if (!q) { panel.classList.add("hidden"); setHTML(panel, ""); return; }
+    panel.classList.remove("hidden");
+    setHTML(panel, '<div class="flex items-center gap-2 text-sm" style="color: var(--text-muted);"><div class="kb-spin"></div> Retrieving from the Knowledge Base…</div>');
+    getJSON("/api/kb/search?q=" + encodeURIComponent(q)).then(function (data) {
+      if (data.error) {
+        setHTML(panel, '<div class="kb-banner kb-banner-warn">' + esc(data.error) + "</div>");
+        return;
+      }
+      var results = data.results || [];
+      if (!results.length) {
+        setHTML(panel, '<div class="flex items-center justify-between"><span class="text-sm" style="color: var(--text-muted);">No passages retrieved for &ldquo;' + esc(q) + '&rdquo;.</span>' +
+          '<button onclick="kbClearSearch()" class="tg-mono text-[11px]" style="color: var(--text-subtle);">clear ✕</button></div>');
+        return;
+      }
+      var html = '<div class="flex items-center justify-between mb-2"><span class="tg-section-label">Top ' + results.length + ' passages</span>' +
+        '<button onclick="kbClearSearch()" class="tg-mono text-[11px]" style="color: var(--text-subtle);">clear ✕</button></div>';
+      html += '<div class="space-y-2 kb-scroll" style="max-height: 260px;">';
+      results.forEach(function (r) {
+        var fname = (r.uri || "").split("/").pop();
+        html += '<div class="rounded-lg p-3" style="background: var(--surface); border: 1px solid var(--border);">' +
+          '<div class="flex items-center gap-2 mb-1">' +
+          '<span class="tg-mono text-[10px] px-1.5 py-0.5 rounded" style="background: rgba(var(--primary-rgb),0.14); color: var(--primary);">score ' + esc(r.score) + "</span>" +
+          '<span class="tg-mono text-[10px] truncate" style="color: var(--text-subtle);">' + esc(fname) + "</span></div>" +
+          '<p class="text-xs" style="color: var(--text-muted); line-height: 1.55;">' + esc((r.content || "").slice(0, 600)) + ((r.content || "").length > 600 ? "…" : "") + "</p></div>";
+      });
+      html += "</div>";
+      setHTML(panel, html);
+    }).catch(function (e) {
+      setHTML(panel, '<div class="kb-banner kb-banner-warn">Search failed: ' + esc(e.message) + "</div>");
+    });
+  };
+
+  window.kbClearSearch = function () {
+    el("kb-search").value = "";
+    var panel = el("kb-results");
+    panel.classList.add("hidden");
+    setHTML(panel, "");
+  };
+
+  // ── Upload ──────────────────────────────────────────────────────────────
+  window.kbUpload = function (file) {
+    if (!file) return;
+    var status = el("kb-upload-status");
+    status.classList.remove("hidden");
+    setHTML(status, '<div class="kb-banner" style="border-color: var(--border); color: var(--text-muted); display:flex; align-items:center; gap:.5rem;"><div class="kb-spin"></div> Uploading ' + esc(file.name) + "…</div>");
+
+    var form = new FormData();
+    form.append("file", file);
+    fetch("/api/kb/upload", { method: "POST", credentials: "same-origin", body: form })
+      .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+      .then(function (res) {
+        var d = res.data || {};
+        if (!res.ok || d.error) {
+          setHTML(status, '<div class="kb-banner kb-banner-warn">Upload failed: ' + esc(d.error || "unknown error") + "</div>");
+          return;
+        }
+        var msg = "Uploaded <span class=\"tg-mono\">" + esc(d.name) + "</span>.";
+        if (d.ingestion_job_id) {
+          msg += " Ingestion started (job " + esc(d.ingestion_job_id) + "). New content is retrievable in a few minutes.";
+        } else if (d.ingestion_error) {
+          msg += " The file was stored, but ingestion could not be started automatically: " + esc(d.ingestion_error) + ". Start an ingestion job manually.";
+        }
+        setHTML(status, '<div class="kb-banner kb-banner-ok">' + msg + "</div>");
+        loadDocs();
+      })
+      .catch(function (e) {
+        setHTML(status, '<div class="kb-banner kb-banner-warn">Upload failed: ' + esc(e.message) + "</div>");
+      })
+      .finally(function () {
+        var input = el("kb-file");
+        if (input) input.value = "";
+      });
+  };
+
+  // ── Init ───────────────────────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", loadDocs);
+})();

--- a/chatapp/app/storage/knowledge_base.py
+++ b/chatapp/app/storage/knowledge_base.py
@@ -1,0 +1,282 @@
+"""Read/write browsing of the Bedrock Knowledge Base source documents.
+
+Powers the **Knowledge Base Explorer** page (``/admin/kb``). Two data sources,
+both the very same ones the agent relies on at query time:
+
+1. **Source documents** — the files the Knowledge Base was built from, stored in
+   the KB source S3 bucket under the ``documents/`` prefix. They can be listed,
+   read (when text-based), and new ones can be uploaded.
+2. **Semantic retrieval** — ``bedrock-agent-runtime:Retrieve`` against the
+   vector Knowledge Base, i.e. exactly what the agent sees for a query.
+
+There are **no document scopes** here: the explorer shows a single flat list of
+every document under the ``documents/`` prefix.
+
+Everything is **best-effort**: every public coroutine catches its own errors and
+returns a structured dict with an ``error`` key rather than raising, so the UI
+always renders.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from functools import lru_cache
+from typing import Any, Optional
+
+import boto3
+from botocore.config import Config
+
+logger = logging.getLogger(__name__)
+
+# ── Configuration (env-resolved) ─────────────────────────────────────────────
+_REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+
+# The data source ingests this prefix (see cdk/lib/bedrock-stack.ts inclusionPrefixes).
+_DOC_PREFIX = "documents/"
+# Uploaded files land under this sub-prefix so they're easy to distinguish from
+# seeded content.
+_UPLOAD_PREFIX = "documents/uploads/"
+
+# Read cap so a huge file can't blow up the page.
+_MAX_READ_BYTES = 512_000
+# Upload cap (10 MB) — generous for documents, bounded for safety.
+_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+# File extensions we render inline as text.
+_TEXT_EXTENSIONS = {
+    ".md", ".markdown", ".txt", ".text", ".json", ".csv", ".tsv",
+    ".yaml", ".yml", ".html", ".htm", ".xml", ".log", ".rst",
+}
+# Extensions accepted for upload (text + common docs that Bedrock can parse).
+_UPLOAD_EXTENSIONS = _TEXT_EXTENSIONS | {".pdf", ".doc", ".docx"}
+
+# Filenames are sanitized to this character set.
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+@lru_cache(maxsize=1)
+def _cfg() -> Config:
+    return Config(region_name=_REGION, retries={"max_attempts": 2, "mode": "adaptive"})
+
+
+@lru_cache(maxsize=1)
+def _s3():
+    return boto3.client("s3", config=_cfg())
+
+
+@lru_cache(maxsize=1)
+def _kb_runtime():
+    return boto3.client("bedrock-agent-runtime", config=_cfg())
+
+
+@lru_cache(maxsize=1)
+def _kb_agent():
+    return boto3.client("bedrock-agent", config=_cfg())
+
+
+def _source_bucket() -> Optional[str]:
+    return os.environ.get("KB_SOURCE_BUCKET", "").strip() or None
+
+
+def _kb_id() -> Optional[str]:
+    return os.environ.get("KB_ID", "").strip() or None
+
+
+def is_configured() -> bool:
+    """True when both the KB id and source bucket are available."""
+    return bool(_kb_id() and _source_bucket())
+
+
+def _ext(name: str) -> str:
+    idx = name.rfind(".")
+    return name[idx:].lower() if idx != -1 else ""
+
+
+# ── Document listing ──────────────────────────────────────────────────────────
+def _list_objects_sync(bucket: str, prefix: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    paginator = _s3().get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if key.endswith("/"):
+                continue
+            name = key.rsplit("/", 1)[-1]
+            out.append({
+                "key": key,
+                "name": name,
+                "size": obj.get("Size", 0),
+                "last_modified": obj.get("LastModified").isoformat() if obj.get("LastModified") else "",
+                "readable": _ext(name) in _TEXT_EXTENSIONS,
+            })
+    return out
+
+
+async def list_documents() -> dict[str, Any]:
+    """List every KB source document under the ``documents/`` prefix (flat)."""
+    bucket = _source_bucket()
+    if not bucket:
+        return {"documents": [], "error": "Knowledge Base source bucket is not configured."}
+
+    try:
+        loop = asyncio.get_event_loop()
+        docs = await loop.run_in_executor(None, _list_objects_sync, bucket, _DOC_PREFIX)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("KB list failed: %s", e)
+        return {"documents": [], "error": f"Could not list documents: {e}"}
+
+    docs.sort(key=lambda d: d["name"].lower())
+    return {"documents": docs, "bucket": bucket}
+
+
+# ── Document read ──────────────────────────────────────────────────────────────
+def _get_object_text_sync(bucket: str, key: str) -> str:
+    obj = _s3().get_object(Bucket=bucket, Key=key)
+    body = obj["Body"].read(_MAX_READ_BYTES + 1)
+    text = body[:_MAX_READ_BYTES].decode("utf-8", errors="replace")
+    if len(body) > _MAX_READ_BYTES:
+        text += "\n\n… [truncated]"
+    return text
+
+
+async def get_document(key: str) -> dict[str, Any]:
+    """Return the text content of one KB source document. Best-effort."""
+    bucket = _source_bucket()
+    if not bucket:
+        return {"error": "Knowledge Base source bucket is not configured."}
+    # Guard against path traversal and reading outside the documents/ prefix.
+    if not key or ".." in key or not key.startswith(_DOC_PREFIX):
+        return {"error": "Invalid document key."}
+
+    name = key.rsplit("/", 1)[-1]
+    if _ext(name) not in _TEXT_EXTENSIONS:
+        return {
+            "key": key,
+            "name": name,
+            "readable": False,
+            "content": "",
+            "notice": "Preview is not available for this file type. Text formats "
+                      "(Markdown, TXT, JSON, CSV, YAML, HTML, XML) render inline.",
+        }
+
+    try:
+        loop = asyncio.get_event_loop()
+        content = await loop.run_in_executor(None, _get_object_text_sync, bucket, key)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("KB get_object failed (%s): %s", key, e)
+        return {"error": f"Could not read document: {e}"}
+    return {"key": key, "name": name, "readable": True, "content": content}
+
+
+# ── Semantic search ────────────────────────────────────────────────────────────
+def _retrieve_sync(kb_id: str, query: str, n: int) -> list[dict[str, Any]]:
+    resp = _kb_runtime().retrieve(
+        knowledgeBaseId=kb_id,
+        retrievalQuery={"text": query},
+        retrievalConfiguration={"vectorSearchConfiguration": {"numberOfResults": n}},
+    )
+    hits = []
+    for r in resp.get("retrievalResults", []):
+        hits.append({
+            "score": round(r.get("score") or 0.0, 4),
+            "content": (r.get("content") or {}).get("text", ""),
+            "uri": (r.get("location") or {}).get("s3Location", {}).get("uri", ""),
+        })
+    return hits
+
+
+async def search(query: str, n: int = 5) -> dict[str, Any]:
+    """Semantic search against the vector Knowledge Base (what the agent sees)."""
+    if not query or not query.strip():
+        return {"results": [], "error": "Enter a search query."}
+    kb_id = _kb_id()
+    if not kb_id:
+        return {"results": [], "error": "Knowledge Base is not configured."}
+    try:
+        loop = asyncio.get_event_loop()
+        results = await loop.run_in_executor(
+            None, _retrieve_sync, kb_id, query.strip(), max(1, min(int(n), 10))
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("KB retrieve failed: %s", e)
+        return {"results": [], "error": f"Retrieval failed: {e}"}
+    return {"results": results}
+
+
+# ── Upload + ingestion ──────────────────────────────────────────────────────────
+def _safe_filename(filename: str) -> str:
+    """Strip any path and reduce to a safe, predictable filename."""
+    base = (filename or "").rsplit("/", 1)[-1].rsplit("\\", 1)[-1].strip()
+    base = _SAFE_NAME_RE.sub("-", base).strip("-._")
+    return base or "upload"
+
+
+def _start_ingestion_sync(kb_id: str) -> Optional[str]:
+    """Start an ingestion job for the KB's first data source. Returns job id."""
+    ds = _kb_agent().list_data_sources(knowledgeBaseId=kb_id, maxResults=1)
+    summaries = ds.get("dataSourceSummaries", [])
+    if not summaries:
+        raise RuntimeError("No data source found for the Knowledge Base.")
+    data_source_id = summaries[0]["dataSourceId"]
+    job = _kb_agent().start_ingestion_job(
+        knowledgeBaseId=kb_id,
+        dataSourceId=data_source_id,
+        description="Triggered by Knowledge Base Explorer upload",
+    )
+    return job.get("ingestionJob", {}).get("ingestionJobId")
+
+
+def _put_object_sync(bucket: str, key: str, data: bytes, content_type: str) -> None:
+    _s3().put_object(Bucket=bucket, Key=key, Body=data, ContentType=content_type)
+
+
+async def upload_document(filename: str, data: bytes, content_type: str = "") -> dict[str, Any]:
+    """Write a new document under ``documents/uploads/`` and start ingestion.
+
+    Returns a dict with ``key`` and ``ingestion_job_id`` on success, or ``error``.
+    """
+    bucket = _source_bucket()
+    kb_id = _kb_id()
+    if not bucket or not kb_id:
+        return {"error": "Knowledge Base is not configured."}
+
+    if not data:
+        return {"error": "The uploaded file is empty."}
+    if len(data) > _MAX_UPLOAD_BYTES:
+        return {"error": f"File exceeds the {_MAX_UPLOAD_BYTES // (1024 * 1024)} MB upload limit."}
+
+    safe = _safe_filename(filename)
+    if _ext(safe) not in _UPLOAD_EXTENSIONS:
+        allowed = ", ".join(sorted(_UPLOAD_EXTENSIONS))
+        return {"error": f"Unsupported file type. Allowed: {allowed}"}
+
+    key = f"{_UPLOAD_PREFIX}{safe}"
+    loop = asyncio.get_event_loop()
+    try:
+        await loop.run_in_executor(
+            None, _put_object_sync, bucket, key, data, content_type or "application/octet-stream"
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("KB upload put_object failed (%s): %s", key, e)
+        return {"error": f"Upload failed: {e}"}
+
+    # Best-effort ingestion trigger — the file is stored even if this fails.
+    job_id: Optional[str] = None
+    ingestion_error: Optional[str] = None
+    try:
+        job_id = await loop.run_in_executor(None, _start_ingestion_sync, kb_id)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("KB start_ingestion_job failed: %s", e)
+        ingestion_error = str(e)
+
+    return {
+        "key": key,
+        "name": safe,
+        "size": len(data),
+        "ingestion_job_id": job_id,
+        "ingestion_error": ingestion_error,
+    }

--- a/chatapp/app/storage/knowledge_base.py
+++ b/chatapp/app/storage/knowledge_base.py
@@ -127,7 +127,7 @@ async def list_documents() -> dict[str, Any]:
         docs = await loop.run_in_executor(None, _list_objects_sync, bucket, _DOC_PREFIX)
     except Exception as e:  # noqa: BLE001
         logger.warning("KB list failed: %s", e)
-        return {"documents": [], "error": f"Could not list documents: {e}"}
+        return {"documents": [], "error": "Could not list documents. Check the server logs for details."}
 
     docs.sort(key=lambda d: d["name"].lower())
     return {"documents": docs, "bucket": bucket}
@@ -168,7 +168,7 @@ async def get_document(key: str) -> dict[str, Any]:
         content = await loop.run_in_executor(None, _get_object_text_sync, bucket, key)
     except Exception as e:  # noqa: BLE001
         logger.warning("KB get_object failed (%s): %s", key, e)
-        return {"error": f"Could not read document: {e}"}
+        return {"error": "Could not read document. Check the server logs for details."}
     return {"key": key, "name": name, "readable": True, "content": content}
 
 
@@ -203,7 +203,7 @@ async def search(query: str, n: int = 5) -> dict[str, Any]:
         )
     except Exception as e:  # noqa: BLE001
         logger.warning("KB retrieve failed: %s", e)
-        return {"results": [], "error": f"Retrieval failed: {e}"}
+        return {"results": [], "error": "Retrieval failed. Check the server logs for details."}
     return {"results": results}
 
 
@@ -262,7 +262,7 @@ async def upload_document(filename: str, data: bytes, content_type: str = "") ->
         )
     except Exception as e:  # noqa: BLE001
         logger.warning("KB upload put_object failed (%s): %s", key, e)
-        return {"error": f"Upload failed: {e}"}
+        return {"error": "Upload failed. Check the server logs for details."}
 
     # Best-effort ingestion trigger — the file is stored even if this fails.
     job_id: Optional[str] = None
@@ -271,7 +271,7 @@ async def upload_document(filename: str, data: bytes, content_type: str = "") ->
         job_id = await loop.run_in_executor(None, _start_ingestion_sync, kb_id)
     except Exception as e:  # noqa: BLE001
         logger.warning("KB start_ingestion_job failed: %s", e)
-        ingestion_error = str(e)
+        ingestion_error = "Ingestion could not be started. Check the server logs for details."
 
     return {
         "key": key,

--- a/chatapp/app/templates/admin/knowledge_base.html
+++ b/chatapp/app/templates/admin/knowledge_base.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block title %}Knowledge Base · {{ app_title if app_title is defined else 'AgentCore Chat' }}{% endblock %}
+
+{% block favicon %}
+<link rel="icon" type="image/svg+xml" href="{{ logo_url if logo_url is defined else '/static/favicon.svg' }}">
+{% endblock %}
+
+{% block head %}
+<style>
+    .tg-mono { font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; }
+
+    /* List items (docs) */
+    .kb-item {
+        display: flex; align-items: center; gap: 0.6rem; width: 100%;
+        padding: 0.6rem 0.85rem; border-radius: 10px; cursor: pointer; text-align: left;
+        color: var(--text-muted); border: 1px solid transparent;
+        transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+    }
+    .kb-item:hover { background: var(--surface-2); color: var(--text); }
+    .kb-item.is-active { background: rgba(var(--primary-rgb), 0.12); color: var(--text); border-color: rgba(var(--primary-rgb), 0.35); }
+
+    .kb-scroll { overflow: auto; }
+    .kb-scroll::-webkit-scrollbar { width: 9px; height: 9px; }
+    .kb-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 5px; }
+
+    .kb-field {
+        background: var(--surface); border: 1px solid var(--border); color: var(--text);
+        border-radius: 10px;
+    }
+    .kb-field:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.18); }
+
+    .kb-doc { font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-size: 0.8rem; line-height: 1.65; white-space: pre-wrap; word-break: break-word; color: var(--text-muted); }
+
+    .kb-banner { border-radius: 10px; padding: 0.7rem 0.9rem; font-size: 0.8rem; border: 1px solid; }
+    .kb-banner-warn { background: rgba(245,158,11,0.12); border-color: rgba(245,158,11,0.35); color: #b45309; }
+    html[data-theme="dark"] .kb-banner-warn { color: #fbbf24; }
+    .kb-banner-ok { background: rgba(34,197,94,0.12); border-color: rgba(34,197,94,0.35); color: #15803d; }
+    html[data-theme="dark"] .kb-banner-ok { color: #4ade80; }
+
+    .kb-spin { width: 1.25rem; height: 1.25rem; border: 2px solid currentColor; border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite; }
+
+    @keyframes kbRise { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+    .kb-rise { animation: kbRise 0.3s cubic-bezier(0.22,1,0.36,1) both; }
+</style>
+{% endblock %}
+
+{% block body %}
+<div class="min-h-screen bg-gray-50" style="background: var(--background);">
+
+    <!-- Header -->
+    {% include "components/header.html" %}
+
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <!-- Heading + controls (matches the other admin pages) -->
+        <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4 mb-7">
+            <div class="min-w-0">
+                <p class="text-xs font-mono uppercase tracking-[0.2em] mb-1" style="color: var(--text-subtle);">Configuration</p>
+                <h1 class="font-display text-2xl sm:text-3xl font-bold" style="color: var(--text);">Knowledge Base</h1>
+                <p class="mt-1 text-sm max-w-2xl" style="color: var(--text-muted);">
+                    Browse the documents the agent retrieves from, run the same semantic search the agent uses, and upload new source files.
+                </p>
+            </div>
+            <div class="flex items-center gap-2 w-full lg:w-auto shrink-0">
+                <div class="relative flex-1 lg:flex-none">
+                    <svg class="w-4 h-4 absolute left-2.5 top-1/2 -translate-y-1/2" style="color: var(--text-subtle);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/></svg>
+                    <input id="kb-search" type="text" placeholder="Semantic search (what the agent retrieves)…"
+                           class="kb-field text-sm pl-8 pr-3 py-2 w-full lg:w-80"
+                           onkeydown="if(event.key==='Enter'){kbSearch();}">
+                </div>
+                <button onclick="kbSearch()" class="text-sm px-3 py-2 rounded-lg font-semibold text-white bg-primary-600 hover:bg-primary-700 transition-colors shrink-0">Search</button>
+                {% if is_admin %}
+                <input id="kb-file" type="file" class="hidden"
+                       accept=".md,.markdown,.txt,.text,.json,.csv,.tsv,.yaml,.yml,.html,.htm,.xml,.log,.rst,.pdf,.doc,.docx"
+                       onchange="kbUpload(this.files[0])">
+                <button onclick="document.getElementById('kb-file').click()"
+                        class="kb-field text-sm px-3 py-2 inline-flex items-center gap-1.5 shrink-0" style="color: var(--text-muted);" title="Upload a document into the Knowledge Base">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"/></svg>
+                    <span class="hidden sm:inline">Upload</span>
+                </button>
+                {% endif %}
+            </div>
+        </div>
+
+        <div id="kb-upload-status" class="mb-4 hidden"></div>
+
+        {% if not kb_configured %}
+        <div class="kb-banner kb-banner-warn mb-4">
+            The Knowledge Base is not fully configured. Ensure <span class="tg-mono">KB_ID</span> and
+            <span class="tg-mono">KB_SOURCE_BUCKET</span> are set for the chat application.
+        </div>
+        {% endif %}
+
+        <!-- Explorer: documents + content, in a bounded card -->
+        <div class="rounded-lg shadow-sm border overflow-hidden flex"
+             style="background: var(--surface); border-color: var(--border); height: calc(100vh - 330px); min-height: 460px;">
+            <!-- Document list -->
+            <aside class="w-[230px] md:w-[280px] shrink-0 flex flex-col min-h-0" style="border-right: 1px solid var(--border);">
+                <div class="px-4 py-3 shrink-0 flex items-center justify-between" style="border-bottom: 1px solid var(--border);">
+                    <span class="font-display font-bold text-sm" style="color: var(--text);">Documents</span>
+                    <span id="kb-doc-count" class="tg-mono text-[11px] px-1.5 py-0.5 rounded" style="background: var(--surface-2); color: var(--text-muted);">0</span>
+                </div>
+                <div id="kb-doc-list" class="flex-1 kb-scroll p-2 space-y-1 min-h-0"></div>
+            </aside>
+
+            <!-- Content pane -->
+            <main class="flex-1 min-w-0 flex flex-col min-h-0" style="background: var(--background);">
+                <div id="kb-results" class="hidden px-4 sm:px-5 py-3 shrink-0" style="border-bottom: 1px solid var(--border);"></div>
+                <div class="px-4 sm:px-5 py-3 shrink-0" style="border-bottom: 1px solid var(--border);">
+                    <div id="kb-doc-title" class="font-display font-bold text-sm truncate" style="color: var(--text);">Select a document</div>
+                    <div id="kb-doc-sub" class="tg-mono text-[11px] truncate" style="color: var(--text-subtle);">Documents the knowledge base was built from</div>
+                </div>
+                <div id="kb-doc-body" class="flex-1 kb-scroll min-h-0 p-5">
+                    <div class="h-full flex items-center justify-center text-center">
+                        <div class="max-w-sm">
+                            <div class="mx-auto w-14 h-14 rounded-2xl flex items-center justify-center mb-4" style="background: rgba(var(--primary-rgb), 0.12);">
+                                <svg class="w-7 h-7 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg>
+                            </div>
+                            <h3 class="font-display font-bold mb-1" style="color: var(--text);">Browse the knowledge base</h3>
+                            <p class="text-sm" style="color: var(--text-muted);">Open a document on the left to read its contents, or run a semantic search to see what the agent retrieves.</p>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </main>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/knowledge_base.js?v={{ asset_version() }}"></script>
+{% endblock %}

--- a/chatapp/app/templates/components/header.html
+++ b/chatapp/app/templates/components/header.html
@@ -129,6 +129,12 @@
                         </svg>
                         <span>Guardrails Violations</span>
                     </a>
+                    <a href="/admin/tools" class="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors" style="color: var(--text-muted);">
+                        <svg class="w-4 h-4 flex-shrink-0" style="color: var(--text-subtle);" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
+                        </svg>
+                        <span>Tool Usage</span>
+                    </a>
                     <a href="/admin/evaluations" class="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors" style="color: var(--text-muted);">
                         <svg class="w-4 h-4 flex-shrink-0" style="color: var(--text-subtle);" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
@@ -141,13 +147,13 @@
                         </svg>
                         <span>User Feedback</span>
                     </a>
-                    <a href="/admin/tools" class="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors" style="color: var(--text-muted);">
-                        <svg class="w-4 h-4 flex-shrink-0" style="color: var(--text-subtle);" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
-                        </svg>
-                        <span>Tool Usage</span>
-                    </a>
                     <div class="my-1" style="border-top: 1px solid var(--border);"></div>
+                    <a href="/admin/kb" class="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors" style="color: var(--text-muted);">
+                        <svg class="w-4 h-4 flex-shrink-0" style="color: var(--text-subtle);" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+                        </svg>
+                        <span>Knowledge Base</span>
+                    </a>
                     <a href="/admin/templates" class="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors" style="color: var(--text-muted);">
                         <svg class="w-4 h-4 flex-shrink-0" style="color: var(--text-subtle);" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />

--- a/chatapp/sync-env.sh
+++ b/chatapp/sync-env.sh
@@ -114,6 +114,21 @@ GUARDRAIL_ID=$(echo "$SECRET_VALUE" | jq -r '.guardrail_id // empty')
 GUARDRAIL_VERSION=$(echo "$SECRET_VALUE" | jq -r '.guardrail_version // empty')
 KB_ID=$(echo "$SECRET_VALUE" | jq -r '.kb_id // empty')
 
+# KB_SOURCE_BUCKET is not stored in the secret — it has a deterministic name
+# (${APP_NAME}-kb-${ACCOUNT}-${REGION}, see cdk/lib/bedrock-stack.ts SourceBucket).
+# Resolve the account ID so the Knowledge Base Explorer can list/read/upload
+# documents during local development.
+KB_SOURCE_BUCKET=$(echo "$SECRET_VALUE" | jq -r '.kb_source_bucket // empty')
+if [ -z "$KB_SOURCE_BUCKET" ]; then
+    ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text --region "$AWS_REGION" 2>/dev/null || true)
+    if [ -n "$ACCOUNT_ID" ]; then
+        KB_SOURCE_BUCKET="${APP_NAME}-kb-${ACCOUNT_ID}-${AWS_REGION}"
+    else
+        echo -e "${YELLOW}Warning: could not resolve AWS account ID; KB_SOURCE_BUCKET left blank.${NC}"
+        echo -e "${YELLOW}The Knowledge Base Explorer's document browsing/upload will be disabled locally.${NC}"
+    fi
+fi
+
 # Validate required values
 if [ -z "$AGENTCORE_RUNTIME_ARN" ]; then
     echo -e "${RED}Error: AGENTCORE_RUNTIME_ARN is empty. Agent stack may not be fully deployed.${NC}"
@@ -169,6 +184,7 @@ GUARDRAIL_ENABLED=true
 
 # Knowledge Base Configuration
 KB_ID=$KB_ID
+KB_SOURCE_BUCKET=$KB_SOURCE_BUCKET
 
 # Application Configuration
 APP_URL=http://localhost:8080


### PR DESCRIPTION
## Summary

Adds a **Knowledge Base Explorer** to the admin app and makes the Knowledge Base useful out of the box.

- **Seed + auto-ingest (CDK):** a default KB article is deployed into the source bucket under `documents/` and an ingestion job runs on deploy, so the agent has retrievable content and the Explorer has a document to show immediately.
- **Explorer (`/admin/kb`):** browse source documents, read text-based files inline, run the same semantic `Retrieve` the agent uses, and upload new documents (written to `documents/uploads/` and auto-ingested).
- **IAM + wiring:** the chatapp task role gets `bedrock:Retrieve` + ingestion actions and scoped S3 access to the KB source bucket; `KB_SOURCE_BUCKET` is injected into the ECS and Lambda environments and documented for local dev.

## Changes by area

- **cdk:** `bedrock-stack.ts` (seed `BucketDeployment` + `StartKbIngestion` custom resource + nag suppressions), `foundation-stack.ts` (KB Explorer IAM), `chatapp-stack.ts` (`KB_SOURCE_BUCKET` env), `assets/kb-seed/about-agentcore-chat-app.md`
- **chatapp:** `routes/knowledge_base.py`, `storage/knowledge_base.py`, `static/js/knowledge_base.js`, `templates/admin/knowledge_base.html`, `main.py` (router wiring), `components/header.html` (admin-menu link)
- **config:** `.env.example`, `sync-env.sh` (`KB_SOURCE_BUCKET`)

## Testing

- `npm run build` (cdk) compiles cleanly.
- `python -m py_compile` passes for the new KB modules and `main.py`.
- `node --check` passes for `knowledge_base.js`.

## Notes

- Upload endpoint is admin-gated; document read is path-traversal guarded and limited to the `documents/` prefix.
- The seeded ingestion re-runs each deploy (timestamped client token) and uses `prune: false`, so admin/agent-uploaded documents are never deleted.
