### PR TITLE
feat(evals): track and surface LLM-judge cost

### DIFF
--- a/chatapp/app/admin/evaluation_repository.py
+++ b/chatapp/app/admin/evaluation_repository.py
@@ -69,11 +69,14 @@ class EvaluationRepository:
         num_evaluators = len(scores_by_eval)
         approx_messages = total_evals // max(num_evaluators, 1)
         total_failed = sum(1 for r in records if not r.passed)
+        # Sum the cost of the LLM-judge calls (programmatic evaluators are 0).
+        total_cost = round(sum(r.cost for r in records), 6)
 
         return EvaluationAggregateStats(
             total_evaluations=total_evals,
             total_messages_evaluated=approx_messages,
             total_failed=total_failed,
+            total_cost=total_cost,
             avg_scores=avg_scores,
             pass_rates=pass_rates,
             eval_counts=eval_counts,
@@ -230,6 +233,10 @@ class EvaluationRepository:
                 "label": record.label,
                 "reason": record.reason,
                 "latency_ms": record.latency_ms,
+                "judge_model_id": record.judge_model_id,
+                "input_tokens": record.input_tokens,
+                "output_tokens": record.output_tokens,
+                "cost": record.cost,
             })
 
         result = []
@@ -239,6 +246,7 @@ class EvaluationRepository:
             scores = [e["score"] for e in evals]
             turn["avg_score"] = round(sum(scores) / len(scores), 3) if scores else 0.0
             turn["all_passed"] = all(e["passed"] for e in evals) if evals else False
+            turn["cost"] = round(sum(e.get("cost", 0.0) for e in evals), 6)
             # Stable ordering of evaluators within a turn
             turn["evaluations"] = sorted(evals, key=lambda e: e["evaluator_name"])
             result.append(turn)

--- a/chatapp/app/evaluations/config.py
+++ b/chatapp/app/evaluations/config.py
@@ -21,9 +21,11 @@ class EvalConfig:
         llm_sample_rate: Fraction of turns (0.0-1.0) on which to run LLM judges.
             Programmatic evaluators always run. Defaults to 1.0 (every turn);
             lower it to control cost in higher-traffic deployments.
-        max_output_length: Max chars of agent output to send to judge (cost control)
+        max_output_length: Max chars of agent output to send to judge. 0 (default)
+            means no truncation — send the full response.
         max_context_length: Max chars of retrieved source context to send to the
-            faithfulness judge (larger than output so grounding is not truncated)
+            faithfulness judge. 0 (default) means no truncation — send the full
+            source material so grounding is never cut.
         max_reason_length: Max chars to store for evaluation reasons
     """
     enabled: bool = True
@@ -36,8 +38,13 @@ class EvalConfig:
         "tool_selection",
     ])
     llm_sample_rate: float = 1.0
-    max_output_length: int = 16000
-    max_context_length: int = 100000
+    # 0 (or any non-positive value) means "no truncation" — send the full agent
+    # output and full source context to the judge. Truncating either causes
+    # faithfulness/quality false negatives because the judge can't see the
+    # content the response is actually grounded in. Set a positive limit only if
+    # you explicitly need to cap cost.
+    max_output_length: int = 0
+    max_context_length: int = 0
     max_reason_length: int = 2000
 
     @classmethod
@@ -70,10 +77,16 @@ class EvalConfig:
             sample_rate = 1.0
         sample_rate = max(0.0, min(1.0, sample_rate))
 
+        # 0 = no truncation (default). Only a positive value imposes a cap.
         try:
-            max_context = int(os.environ.get("EVALUATIONS_MAX_CONTEXT_LENGTH", "20000"))
+            max_context = int(os.environ.get("EVALUATIONS_MAX_CONTEXT_LENGTH", "0"))
         except ValueError:
-            max_context = 20000
+            max_context = 0
+
+        try:
+            max_output = int(os.environ.get("EVALUATIONS_MAX_OUTPUT_LENGTH", "0"))
+        except ValueError:
+            max_output = 0
 
         return cls(
             enabled=enabled,
@@ -82,4 +95,5 @@ class EvalConfig:
             programmatic_evaluators=prog_evals,
             llm_sample_rate=sample_rate,
             max_context_length=max_context,
+            max_output_length=max_output,
         )

--- a/chatapp/app/evaluations/engine.py
+++ b/chatapp/app/evaluations/engine.py
@@ -94,7 +94,8 @@ def _run_binary_judge(
         rubric: Binary pass/fail rubric for the judge
         judge_input: The input shown to the judge (question, plus context for
             faithfulness)
-        agent_output: The agent's response (truncated for cost control)
+        agent_output: The agent's full response (sent untruncated unless a
+            positive config.max_output_length is explicitly set)
         config: Evaluation configuration
 
     Returns:
@@ -102,25 +103,48 @@ def _run_binary_judge(
         or None if evaluation fails or the SDK is unavailable.
     """
     try:
-        from strands_evals.evaluators import OutputEvaluator
+        from strands import Agent
         from strands_evals.types import EvaluationData
-
-        truncated_output = agent_output[:config.max_output_length]
-
-        evaluator = OutputEvaluator(
-            rubric=rubric,
-            include_inputs=True,
-            model=config.judge_model_id,
+        from strands_evals.types.evaluation import EvaluationOutput
+        from strands_evals.evaluators.prompt_templates.case_prompt_template import (
+            compose_test_prompt,
         )
-        result = evaluator.evaluate(EvaluationData(
-            input=judge_input,
-            actual_output=truncated_output,
-        ))
+        from strands_evals.evaluators.prompt_templates.prompt_templates import (
+            judge_output_template,
+        )
 
-        if isinstance(result, list):
-            result = result[0] if result else None
+        # Send the full response by default. Truncating the agent output starves
+        # the judge of the very content it must assess, producing false
+        # negatives. Only cap when a positive limit is explicitly configured.
+        judge_output = (
+            agent_output[:config.max_output_length]
+            if config.max_output_length and config.max_output_length > 0
+            else agent_output
+        )
+
+        # Run the judge with the SDK's own prompt composition (identical to
+        # OutputEvaluator) but invoke the agent directly so we can capture the
+        # judge call's token usage — OutputEvaluator.evaluate() discards it.
+        evaluation_case = EvaluationData(input=judge_input, actual_output=judge_output)
+        judge_prompt = compose_test_prompt(
+            evaluation_case=evaluation_case, rubric=rubric, include_inputs=True
+        )
+        judge_agent = Agent(
+            model=config.judge_model_id,
+            system_prompt=judge_output_template,
+            callback_handler=None,
+        )
+        agent_result = judge_agent(judge_prompt, structured_output_model=EvaluationOutput)
+        result = agent_result.structured_output
         if result is None:
             return None
+
+        # Capture judge token usage and price it. accumulated_usage is a dict
+        # {inputTokens, outputTokens, totalTokens}; missing/zero on failure.
+        usage = getattr(agent_result.metrics, "accumulated_usage", None) or {}
+        input_tokens = int(usage.get("inputTokens", 0) or 0)
+        output_tokens = int(usage.get("outputTokens", 0) or 0)
+        cost = _judge_cost(input_tokens, output_tokens, config.judge_model_id)
 
         passed = bool(result.test_pass)
         return EvalResult(
@@ -128,6 +152,10 @@ def _run_binary_judge(
             passed=passed,
             label="Pass" if passed else "Fail",
             reason=(result.reason or "")[:config.max_reason_length],
+            judge_model_id=config.judge_model_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost=cost,
         )
 
     except ImportError:
@@ -136,6 +164,22 @@ def _run_binary_judge(
     except Exception as e:
         logger.error("LLM evaluation failed", extra={"error": str(e)})
         return None
+
+
+def _judge_cost(input_tokens: int, output_tokens: int, judge_model_id: str) -> float:
+    """Price a judge call using the shared CostCalculator / model catalog.
+
+    The CostCalculator resolves fully-qualified Bedrock ids (e.g.
+    ``global.anthropic.claude-haiku-4-5-20251001-v1:0``) to the catalog entry
+    (``anthropic.claude-haiku-4-5``), so judge pricing comes from the same
+    single source of truth (models.json) as agent inference pricing.
+    """
+    try:
+        from app.admin.cost_calculator import CostCalculator
+        return CostCalculator().calculate_cost(input_tokens, output_tokens, judge_model_id)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Failed to compute judge cost: %s", e)
+        return 0.0
 
 
 def _build_grounded_context(context_items: List[str], max_total: int) -> str:
@@ -155,6 +199,12 @@ def _build_grounded_context(context_items: List[str], max_total: int) -> str:
     items = [i for i in context_items if i and i.strip()]
     if not items:
         return ""
+
+    # No budget (<= 0) means send all source material in full. The faithfulness
+    # judge can only verify grounding against complete tool/KB results, so any
+    # truncation here risks false negatives.
+    if not max_total or max_total <= 0:
+        return "\n\n".join(items)
 
     budgets = [0] * len(items)
     remaining = max_total
@@ -361,4 +411,8 @@ def _make_record(
         latency_ms=latency_ms,
         model_id=model_id,
         user_input=user_input,
+        judge_model_id=getattr(result, "judge_model_id", ""),
+        input_tokens=getattr(result, "input_tokens", 0),
+        output_tokens=getattr(result, "output_tokens", 0),
+        cost=getattr(result, "cost", 0.0),
     )

--- a/chatapp/app/evaluations/evaluators.py
+++ b/chatapp/app/evaluations/evaluators.py
@@ -20,11 +20,20 @@ class EvalResult:
         passed: Whether the evaluation passed
         label: Human-readable label
         reason: Explanation of the score
+        judge_model_id: Model that produced the judgment (LLM judges only;
+            empty for programmatic evaluators)
+        input_tokens: Judge prompt tokens (0 for programmatic evaluators)
+        output_tokens: Judge response tokens (0 for programmatic evaluators)
+        cost: USD cost of the judge call (0.0 for programmatic evaluators)
     """
     score: float
     passed: bool
     label: str
     reason: str
+    judge_model_id: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost: float = 0.0
 
 
 class ToolSelectionEvaluator:

--- a/chatapp/app/models/evaluation.py
+++ b/chatapp/app/models/evaluation.py
@@ -29,6 +29,11 @@ class EvaluationRecord:
         eval_type: "llm_judge" or "programmatic"
         latency_ms: How long the evaluation took in milliseconds
         model_id: The model that was evaluated (agent model, not judge model)
+        judge_model_id: The model that performed the evaluation (LLM judge).
+            Empty for programmatic evaluators.
+        input_tokens: Judge prompt tokens consumed (0 for programmatic evaluators)
+        output_tokens: Judge response tokens generated (0 for programmatic evaluators)
+        cost: USD cost of this judge call (0.0 for programmatic evaluators)
     """
     session_id: str
     timestamp: str
@@ -42,6 +47,10 @@ class EvaluationRecord:
     latency_ms: int
     model_id: str
     user_input: str = ""
+    judge_model_id: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost: float = 0.0
 
     def to_dynamodb_item(self) -> Dict[str, Any]:
         """Convert to DynamoDB item format."""
@@ -58,6 +67,10 @@ class EvaluationRecord:
             "latency_ms": {"N": str(self.latency_ms)},
             "model_id": {"S": self.model_id},
             "user_input": {"S": self.user_input[:1000]},  # Truncate long questions
+            "judge_model_id": {"S": self.judge_model_id},
+            "input_tokens": {"N": str(self.input_tokens)},
+            "output_tokens": {"N": str(self.output_tokens)},
+            "cost": {"N": str(self.cost)},
         }
 
     @classmethod
@@ -76,6 +89,10 @@ class EvaluationRecord:
             latency_ms=int(item.get("latency_ms", {}).get("N", "0")),
             model_id=item.get("model_id", {}).get("S", ""),
             user_input=item.get("user_input", {}).get("S", ""),
+            judge_model_id=item.get("judge_model_id", {}).get("S", ""),
+            input_tokens=int(item.get("input_tokens", {}).get("N", "0")),
+            output_tokens=int(item.get("output_tokens", {}).get("N", "0")),
+            cost=float(item.get("cost", {}).get("N", "0")),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -97,6 +114,7 @@ class EvaluationAggregateStats:
     total_evaluations: int = 0
     total_messages_evaluated: int = 0
     total_failed: int = 0
+    total_cost: float = 0.0
     avg_scores: Dict[str, float] = None
     pass_rates: Dict[str, float] = None
     eval_counts: Dict[str, int] = None
@@ -115,6 +133,7 @@ class EvaluationAggregateStats:
             "total_evaluations": self.total_evaluations,
             "total_messages_evaluated": self.total_messages_evaluated,
             "total_failed": self.total_failed,
+            "total_cost": self.total_cost,
             "avg_scores": self.avg_scores,
             "pass_rates": self.pass_rates,
             "eval_counts": self.eval_counts,

--- a/chatapp/app/templates/admin/evaluation_session.html
+++ b/chatapp/app/templates/admin/evaluation_session.html
@@ -54,6 +54,11 @@
                         {% endif %}
                     </div>
                     <div class="flex items-center gap-2">
+                        {% if turn.cost and turn.cost > 0 %}
+                        <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-purple-50 text-purple-700" title="LLM judge cost for this turn">
+                            ${{ "%.4f"|format(turn.cost) }}
+                        </span>
+                        {% endif %}
                         <span class="inline-block px-2 py-0.5 rounded text-xs font-medium
                             {% if turn.avg_score >= 0.7 %}bg-green-100 text-green-700
                             {% elif turn.avg_score >= 0.5 %}bg-yellow-100 text-yellow-700
@@ -93,6 +98,11 @@
                         </div>
                         {% if ev.reason %}
                         <p class="mt-1 text-xs text-gray-600">{{ ev.reason }}</p>
+                        {% endif %}
+                        {% if ev.eval_type == 'llm_judge' and (ev.input_tokens or ev.output_tokens) %}
+                        <p class="mt-1 text-[11px] text-gray-400 font-mono">
+                            {{ "{:,}".format(ev.input_tokens) }} in / {{ "{:,}".format(ev.output_tokens) }} out · ${{ "%.4f"|format(ev.cost) }}
+                        </p>
                         {% endif %}
                     </div>
                     {% endfor %}

--- a/chatapp/app/templates/admin/evaluations.html
+++ b/chatapp/app/templates/admin/evaluations.html
@@ -20,7 +20,7 @@
         <!-- Heading + Time Range -->
         <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4 mb-7">
             <div>
-                <p class="text-xs font-mono uppercase tracking-[0.2em] mb-1" style="color: var(--text-subtle);">Quality</p>
+                <p class="text-xs font-mono uppercase tracking-[0.2em] mb-1" style="color: var(--text-subtle);">Agent</p>
                 <h1 class="font-display text-2xl sm:text-3xl font-bold" style="color: var(--text);">Evaluations</h1>
             </div>
             <div class="card p-2 flex flex-wrap items-center gap-2">
@@ -40,7 +40,7 @@
         </div>
 
         <!-- Summary Cards -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
             <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                 <div class="flex items-center justify-between">
                     <div>
@@ -94,6 +94,22 @@
                     </div>
                 </div>
                 <p class="mt-2 text-xs text-gray-500">Messages passing all evaluations</p>
+            </div>
+
+            <!-- Evaluation (LLM judge) cost — tracked separately from agent inference cost -->
+            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="text-sm font-medium text-gray-500">Evaluation Cost</p>
+                        <p class="text-2xl font-bold text-gray-900 mt-1">${{ "%.4f"|format(stats.total_cost) }}</p>
+                    </div>
+                    <div class="p-3 bg-purple-100 rounded-full">
+                        <svg class="w-6 h-6 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </div>
+                </div>
+                <p class="mt-2 text-xs text-gray-500">LLM-as-a-judge costs only</p>
             </div>
         </div>
 

--- a/chatapp/scripts/generate_test_data.py
+++ b/chatapp/scripts/generate_test_data.py
@@ -426,11 +426,29 @@ def generate_all_data(
                     # Generate evaluation records for this turn (one per evaluator)
                     turn_question = random.choice(USER_MESSAGES)
                     for evaluator in EVALUATORS:
+                        # Judge token usage + cost (llm_judge only; programmatic
+                        # evaluators are zero-cost in-process checks).
+                        judge_model_id = ""
+                        input_tokens = 0
+                        output_tokens = 0
+                        cost = 0.0
                         if evaluator["type"] == "llm_judge":
                             # Binary judges: mostly pass for a working agent
                             passed = random.random() < 0.85
                             score = 1.0 if passed else 0.0
                             label = "Pass" if passed else "Fail"
+                            # Faithfulness sends full source context, so it tends
+                            # to be the larger prompt; both judges emit a short
+                            # structured verdict.
+                            judge_model_id = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+                            input_tokens = random.randint(3000, 14000)
+                            output_tokens = random.randint(40, 200)
+                            # Haiku 4.5: $1.00 in / $5.00 out per 1M tokens
+                            cost = round(
+                                (input_tokens / 1_000_000) * 1.00
+                                + (output_tokens / 1_000_000) * 5.00,
+                                6,
+                            )
                         else:
                             # Programmatic tool_selection: continuous, biased high
                             score = round(random.triangular(0.4, 1.0, 0.85), 3)
@@ -452,6 +470,10 @@ def generate_all_data(
                             "latency_ms": {"N": str(latency)},
                             "model_id": {"S": random.choice(MODELS)},
                             "user_input": {"S": turn_question},
+                            "judge_model_id": {"S": judge_model_id},
+                            "input_tokens": {"N": str(input_tokens)},
+                            "output_tokens": {"N": str(output_tokens)},
+                            "cost": {"N": str(cost)},
                         }
                         evaluation_records.append(eval_record)
                     


### PR DESCRIPTION
## Summary

Tracks the cost of the LLM-as-a-judge evaluation calls and surfaces it in the admin dashboard, separately from agent inference cost.

- **Capture judge usage:** the judge is invoked directly (using the SDK's own prompt composition, identical to `OutputEvaluator`) so the call's token usage is captured instead of discarded, then priced through the shared `CostCalculator`/model catalog (single source of truth, `models.json`).
- **Persist:** `judge_model_id`, `input_tokens`, `output_tokens`, and `cost` are added to `EvalResult` and `EvaluationRecord` (with DynamoDB (de)serialization) and aggregated as total + per-turn cost in the repository.
- **Surface:** a new "Evaluation Cost" summary card and per-turn / per-judge token+cost lines in the session view.
- **Grounding fix:** default truncation off (`EVALUATIONS_MAX_OUTPUT_LENGTH` / `EVALUATIONS_MAX_CONTEXT_LENGTH` = `0`) so faithfulness/quality judges see the full response and source context. Truncation was causing grounding false negatives; a positive limit still caps cost when needed.

## Files

`evaluations/engine.py`, `evaluators.py`, `config.py`, `models/evaluation.py`, `admin/evaluation_repository.py`, `templates/admin/evaluations.html`, `evaluation_session.html`, `scripts/generate_test_data.py`

## Testing

- `python -m py_compile` passes for all changed Python modules and the test-data script.
