### PR TITLE
feat: rebrand default subtitle to 'Bedrock Mantle | AgentCore | Strands'

### DIFF
--- a/cdk/lib/foundation-stack.ts
+++ b/cdk/lib/foundation-stack.ts
@@ -396,7 +396,7 @@ export class FoundationStack extends cdk.Stack {
                 PutRequest: {
                   Item: {
                     setting_key: { S: 'app_subtitle' },
-                    setting_value: { S: 'Mantle | AgentCore | Strands' },
+                    setting_value: { S: 'Bedrock Mantle | AgentCore | Strands' },
                     setting_type: { S: 'text' },
                     description: { S: 'Application subtitle displayed in header' },
                     updated_at: { S: new Date().toISOString() },

--- a/chatapp/app/helpers/settings.py
+++ b/chatapp/app/helpers/settings.py
@@ -10,7 +10,7 @@ from app.storage.app_settings import AppSettingsStorageService
 
 # Default values
 DEFAULT_APP_TITLE = "Chat Agent"
-DEFAULT_APP_SUBTITLE = "Mantle | AgentCore | Strands"
+DEFAULT_APP_SUBTITLE = "Bedrock Mantle | AgentCore | Strands"
 DEFAULT_LOGO_URL = "/static/favicon.svg"
 DEFAULT_CHAT_LOGO_URL = "/static/chat-placeholder.svg"
 DEFAULT_WELCOME_MESSAGE = "Start a conversation by typing a message below"

--- a/chatapp/app/templates/admin/settings.html
+++ b/chatapp/app/templates/admin/settings.html
@@ -140,7 +140,7 @@
                             required
                             maxlength="200"
                             class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                            placeholder="Mantle | AgentCore | Strands"
+                            placeholder="Bedrock Mantle | AgentCore | Strands"
                         />
                         <p class="mt-1 text-xs text-gray-500">
                             Displayed below the title in the header

--- a/chatapp/app/templates/components/header.html
+++ b/chatapp/app/templates/components/header.html
@@ -39,7 +39,7 @@
                         {{ app_title if app_title is defined else 'Chat Agent' }}
                     </h1>
                     <h2 class="text-[11px] sm:text-xs font-mono truncate" style="color: var(--header-text-muted);">
-                        {{ app_subtitle if app_subtitle is defined else 'Mantle | AgentCore | Strands' }}
+                        {{ app_subtitle if app_subtitle is defined else 'Bedrock Mantle | AgentCore | Strands' }}
                     </h2>
                 </div>
             </a>

--- a/chatapp/app/templates/login.html
+++ b/chatapp/app/templates/login.html
@@ -41,7 +41,7 @@
             </div>
             <h1 class="font-display text-3xl font-bold" style="color: var(--text);">{{ app_title if app_title else 'Chat Agent' }}</h1>
             <p class="mt-2 text-sm font-mono" style="color: var(--text-subtle);">
-                {{ app_subtitle if app_subtitle else 'Mantle | AgentCore | Strands' }}
+                {{ app_subtitle if app_subtitle else 'Bedrock Mantle | AgentCore | Strands' }}
             </p>
         </div>
 

--- a/chatapp/app/templates_config.py
+++ b/chatapp/app/templates_config.py
@@ -73,7 +73,7 @@ async def init_template_globals():
         default_palette = generate_color_palette(DEFAULT_PRIMARY_COLOR)
         templates.env.globals.update({
             "app_title": "Chat Agent",
-            "app_subtitle": "Mantle | AgentCore | Strands",
+            "app_subtitle": "Bedrock Mantle | AgentCore | Strands",
             "logo_url": "/static/favicon.svg",
             "chat_logo_url": "/static/chat-placeholder.svg",
             "primary_color": DEFAULT_PRIMARY_COLOR,


### PR DESCRIPTION
## Summary

Updates the default application subtitle from **"Mantle | AgentCore | Strands"** to **"Bedrock Mantle | AgentCore | Strands"** so the branding reflects Amazon Bedrock Mantle.

Changes the default in every place it appears:

- `cdk/lib/foundation-stack.ts` — DynamoDB `app_subtitle` seed value
- `chatapp/app/helpers/settings.py` — `DEFAULT_APP_SUBTITLE`
- `chatapp/app/templates_config.py` — Jinja global default
- `chatapp/app/templates/admin/settings.html` — input placeholder
- `chatapp/app/templates/components/header.html` — header fallback
- `chatapp/app/templates/login.html` — login fallback

Defaults only; an admin-configured subtitle stored in app settings is unchanged.

## Testing

- `npm run build` (cdk) compiles cleanly.
- `python -m py_compile` passes for the changed Python modules.
