### PR TITLE
fix(chatapp): stream AgentCore tokens to the browser incrementally (unblock event loop)

### DIFF
--- a/chatapp/app/agentcore/client.py
+++ b/chatapp/app/agentcore/client.py
@@ -4,9 +4,11 @@ This module provides the AgentCoreClient class for streaming responses
 from the AgentCore Runtime and converting them to typed SSE events.
 """
 
+import asyncio
 import json
 import re
-from typing import AsyncGenerator, Optional, Dict, Any
+import threading
+from typing import AsyncGenerator, Generator, Optional, Dict, Any
 
 import boto3
 from botocore.config import Config
@@ -348,15 +350,89 @@ class AgentCoreClient:
         model_api: str = "messages",
     ) -> AsyncGenerator[SSEEvent, None]:
         """Invoke AgentCore Runtime and stream the response.
-        
+
+        The underlying boto3 ``invoke_agent_runtime`` call and its streaming body
+        are fully synchronous and blocking. Iterating that body directly on the
+        asyncio event loop freezes the loop between chunks, which prevents
+        already-produced SSE bytes from being flushed to the browser and, in
+        compare mode, serializes the per-lane streams so the UI only paints once
+        everything has arrived.
+
+        To keep the event loop free, the blocking read+parse runs in a worker
+        thread (``_invoke_stream_sync``) and the parsed events are bridged back
+        to this coroutine over a thread-safe queue. The loop can then flush each
+        token as it arrives and genuinely interleave multiple concurrent lanes.
+
         Args:
             prompt: User message to send to the agent
             session_id: Session ID for conversation context
             user_id: User ID for memory operations
             model_id: Model identifier for LLM selection
-            
+            model_api: Which Mantle API the model uses (chat/responses/messages)
+
         Yields:
             SSE events as they are received from AgentCore
+        """
+        loop = asyncio.get_running_loop()
+        queue: "asyncio.Queue[Any]" = asyncio.Queue()
+        stop_event = threading.Event()
+        _DONE = object()
+
+        def _pump() -> None:
+            # Runs on a worker thread: drive the blocking sync generator and hand
+            # each event to the loop. call_soon_threadsafe is the supported way to
+            # touch loop/Queue state from another thread.
+            try:
+                for ev in self._invoke_stream_sync(
+                    prompt=prompt,
+                    session_id=session_id,
+                    user_id=user_id,
+                    model_id=model_id,
+                    model_api=model_api,
+                    stop_event=stop_event,
+                ):
+                    loop.call_soon_threadsafe(queue.put_nowait, ev)
+            except Exception as exc:  # noqa: BLE001 - safety net; sync gen maps known errors
+                loop.call_soon_threadsafe(
+                    queue.put_nowait,
+                    ErrorEvent(message='Failed to invoke AgentCore', details=str(exc)),
+                )
+                loop.call_soon_threadsafe(queue.put_nowait, DoneEvent())
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, _DONE)
+
+        # Keep a reference so the executor future isn't GC'd mid-flight.
+        pump_future = loop.run_in_executor(None, _pump)
+        try:
+            while True:
+                item = await queue.get()
+                if item is _DONE:
+                    break
+                yield item
+        finally:
+            # On client disconnect / early close, signal the worker to stop after
+            # its current (uninterruptible) read so it unwinds the boto3 stream.
+            # We intentionally don't await the future here: this finally can run
+            # during generator finalization/cancellation, where awaiting risks a
+            # GeneratorExit/CancelledError clash. The thread observes the flag and
+            # exits on its own after the in-flight read returns.
+            stop_event.set()
+
+    def _invoke_stream_sync(
+        self,
+        prompt: str,
+        session_id: str,
+        user_id: str,
+        model_id: str = "anthropic.claude-haiku-4-5",
+        model_api: str = "messages",
+        stop_event: Optional[threading.Event] = None,
+    ) -> Generator[SSEEvent, None, None]:
+        """Blocking AgentCore invocation + NDJSON parse, as a sync generator.
+
+        Intended to be driven from a worker thread by :meth:`invoke_stream`.
+        Yields the same typed SSE events; checks ``stop_event`` between chunks so
+        a disconnected client unwinds the read promptly (a chunk already in
+        flight cannot be interrupted).
         """
         import codecs
         
@@ -401,6 +477,11 @@ class AgentCoreClient:
             
             # Read chunks from the stream - StreamingBody yields bytes directly
             for chunk in stream:
+                # Stop early if the consumer (client) has gone away. The current
+                # in-flight read cannot be interrupted, but we won't start
+                # parsing/yielding more once cancellation is signalled.
+                if stop_event is not None and stop_event.is_set():
+                    break
                 # Handle different chunk formats and get raw bytes
                 raw_bytes = None
                 if isinstance(chunk, bytes):


### PR DESCRIPTION
## Summary

In compare mode, message text didn't appear on screen until the very end, even though the server received the first token within a few seconds. This fixes that: tokens now stream to the browser incrementally and per lane in parallel.

## Root cause

`AgentCoreClient.invoke_stream` is an `async def`, but it read the AgentCore response with a **synchronous boto3 `StreamingBody`** (`for chunk in stream:`) with no `await` in the loop. Each chunk read is a blocking socket read that runs on the asyncio event loop thread, freezing the loop between chunks. While the loop is frozen it can't flush the SSE bytes already produced for any connection.

In single mode this mostly hid (gaps between chunks let the loop breathe). In compare mode, each lane is its own `StreamingResponse` → its own producer task on the **same event loop**, so the blocking reads couldn't overlap: lanes serialized and the SSE flush path was starved. Net effect — server-measured TTFT was small, but on-screen TTFT ≈ total, and all lanes painted at the end.

## Change

`chatapp/app/agentcore/client.py` only:

- `invoke_stream` is now an async thread-bridge. It runs the blocking read+parse on a worker thread via `loop.run_in_executor`, and bridges parsed `SSEEvent`s back to the coroutine over an `asyncio.Queue` using `loop.call_soon_threadsafe`. The event loop stays free to flush each token as it arrives and to genuinely interleave concurrent lanes.
- The original blocking read/parse logic moved verbatim into a new `_invoke_stream_sync` (a sync generator), with a `threading.Event` checked between chunks so a disconnected client unwinds the read promptly (a chunk already in flight can't be interrupted).
- **Public interface unchanged** (still an async generator yielding `SSEEvent`), so `chat.py` is untouched.

## Testing

- Full pytest suite: **52 passed**.
- Manual verification in compare mode (3 lanes, no-tool prompt) via Playwright, measuring on-screen first-paint (MutationObserver) vs the server-measured TTFT footer:

  | Lane | On-screen first paint | Server TTFT | Incremental DOM updates | Total |
  |---|---|---|---|---|
  | Kimi K2.5 | 4.2s | 2.6s | 8 | 4.3s |
  | Claude Opus #3 | 5.4s | 3.8s | 42 | 7.2s |
  | Claude Opus #1 | 16.5s | 14.9s | 32 | 17.9s |

  On-screen paint now tracks server TTFT (instead of deferring to the end), lanes grow over many incremental updates (`first << last`), and they run concurrently (Kimi finished ~5.9s while Claude #1 hadn't started painting until 16.5s). 0 console errors.

## Notes

This is a chatapp runtime change only — no API or infra changes. The static/template assets are unchanged, so a ChatApp redeploy picks it up without other stack changes.
