### PR TITLE
fix(chatapp): keep markdown tables inside the compare lane bubble

### DIFF
--- a/chatapp/app/templates/base.html
+++ b/chatapp/app/templates/base.html
@@ -476,6 +476,23 @@
         }
         .lane-transcript .message-footer .metrics-pill { max-width: 100%; }
 
+        /* Compare mode: keep markdown tables inside the lane bubble. The global
+           table rules use width:100% with nowrap headers and no width
+           containment, so in a narrow lane the table spills past the bubble.
+           Fixed layout makes the columns share the available width, and allowing
+           cell/header text to wrap (overriding the global th nowrap) prevents the
+           table from forcing the lane wider than its column. */
+        .lane-transcript .markdown-content table {
+            table-layout: fixed;
+            width: 100%;
+            max-width: 100%;
+        }
+        .lane-transcript .markdown-content th,
+        .lane-transcript .markdown-content td {
+            white-space: normal;
+            overflow-wrap: anywhere;
+        }
+
         /* Copy button - always visible with transition */
         .message-bubble .copy-message-btn { transition: all 0.2s ease; }
 


### PR DESCRIPTION
## Summary

In compare mode, a markdown table in an agent response could extend past its lane bubble (spilling over the right edge of the column). This keeps tables contained within the lane.

## Root cause

The global markdown table CSS uses `width: 100%` with `th { white-space: nowrap }` and no width containment. There's no `.table-wrapper` created at runtime (the CSS for it is dormant), so in a narrow compare lane the table's intrinsic width forced the column wider than the bubble.

## Change

`chatapp/app/templates/base.html` — one CSS block scoped to `.lane-transcript`:

```css
.lane-transcript .markdown-content table { table-layout: fixed; width: 100%; max-width: 100%; }
.lane-transcript .markdown-content th,
.lane-transcript .markdown-content td { white-space: normal; overflow-wrap: anywhere; }
```

`table-layout: fixed` makes the columns share the available lane width, and allowing the cells/headers to wrap (overriding the global `th` nowrap) prevents the table from pushing the lane wider. Single view is untouched (no `.lane-transcript` ancestor).

## Testing

Verified in compare mode (3 lanes) via Playwright with a wide 4-column table injected into the middle lane:

- Table right edge **inside** the bubble (700px vs bubble 717px), `tableWithinBubble: true`.
- No internal horizontal overflow (`scrollWidth ≈ clientWidth`).
- Cells wrap at word boundaries; long unbreakable tokens break only when they can't fit. 0 console errors.

Four columns in a ~280px lane is inherently dense, but the table now stays within the bubble instead of overflowing.
